### PR TITLE
Fix PCL Compiler Warnings on Ubuntu 14.04

### DIFF
--- a/scripts/install/pcl_install.bash
+++ b/scripts/install/pcl_install.bash
@@ -7,13 +7,55 @@ install_dependencies() {
         libflann-dev \
         libvtk6-dev \
         libeigen3-dev \
-        libusb-1.0-0-dev
+        libusb-1.0-0-dev \
+        tcl-vtk \
+        python-vtk \
+        libvtk-java
 }
 
 echo "Installing PCL ..."
 
 install_dependencies
 
-sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/pcl
-sudo apt-get -y update
-sudo apt-get -y install -qq libpcl-all
+PCL_VERSION='1.8.0'
+PCL_FILE="pcl-$PCL_VERSION"
+PCL_DIR="pcl-$PCL_FILE"
+PCL_URL="https://github.com/PointCloudLibrary/pcl/archive/pcl-$PCL_VERSION.tar.gz"
+
+# TODO: find a better way to check if already installed from source
+if [ -e "/usr/local/lib/libpcl_2d.so.$PCL_VERSION" ]; then
+    echo "PCL version $PCL_VERSION already installed"
+else
+    echo "Installing PCL version $PCL_VERSION ..."
+    mkdir -p "$DEPS_DIR"
+    cd "$DEPS_DIR"
+    if [[ ! -d "$PCL_DIR" ]]; then
+        wget "$PCL_URL"
+        tar -xf "$PCL_FILE.tar.gz"
+        rm -rf "$PCL_FILE.tar.gz"
+    fi
+    cd "$PCL_DIR"
+    mkdir -p build
+    cd build
+
+    PCL_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11"
+    if [ -n "$CONTINUOUS_INTEGRATION" ]; then
+        # Disable everything unneeded for a faster build
+        PCL_CMAKE_ARGS="${PCL_CMAKE_ARGS} \
+        -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF \
+        -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF \
+        -DWITH_LIBUSB=OFF -DWITH_OPENGL=OFF -DWITH_OPENNI=OFF \
+        -DWITH_OPENNI2=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF -DWITH_VTK=OFF \
+        -DBUILD_CUDA=OFF -DBUILD_GPU=OFF -DBUILD_surface=OFF \
+        -DBUILD_ml=OFF -DBUILD_io=OFF -DBUILD_geometry=OFF \
+        -DBUILD_tracking=OFF"
+    fi
+
+    cmake .. ${PCL_CMAKE_ARGS} > /dev/null
+
+    echo "Building $PCL_FILE"
+    make_with_progress -j4
+
+    sudo make install > /dev/null
+    echo "PCL installed successfully"
+fi

--- a/scripts/install/pcl_install.bash
+++ b/scripts/install/pcl_install.bash
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e  # exit on first error
 
-install_dependencies() {
+install_dependencies_14() {
     sudo apt-get -y install -qq \
-        libboost-all-dev \
-        libflann-dev \
-        libeigen3-dev \
-        libusb-1.0-0-dev \
+    libboost-all-dev \
+    libflann-dev \
+    libeigen3-dev \
+    libusb-1.0-0-dev \
 	libvtk6 \
 	libvtk6-java \
 	python-vtk6 \
@@ -14,50 +14,29 @@ install_dependencies() {
 	libqt5opengl5
 }
 
+install_dependencies_16() {
+    sudo apt-get -y install -qq \
+    libboost-all-dev \
+    libeigen3-dev \
+    libflann-dev \
+    libopenni-dev \
+    libpcl1.7 \
+    libqhull-dev \
+    libvtk6-dev \
+    libvtk6-qt-dev
+}
+
 echo "Installing PCL ..."
 
-install_dependencies
+UBUNTU_VERSION=`lsb_release --release | cut -f2`
 
-DEPS_DIR="/tmp/libwave_deps"
-PCL_VERSION='1.8.0'
-PCL_FILE="pcl-$PCL_VERSION"
-PCL_DIR="pcl-$PCL_FILE"
-PCL_URL="https://github.com/PointCloudLibrary/pcl/archive/pcl-$PCL_VERSION.tar.gz"
+if [ $UBUNTU_VERSION == "16.04" ]; then
+    install_dependencies_16
+    sudo apt-get -y install -qq libpcl-dev
 
-# TODO: find a better way to check if already installed from source
-if [ -e "/usr/local/lib/libpcl_2d.so.$PCL_VERSION" ]; then
-    echo "PCL version $PCL_VERSION already installed"
-else
-    echo "Installing PCL version $PCL_VERSION ..."
-    mkdir -p "$DEPS_DIR"
-    cd "$DEPS_DIR"
-    if [[ ! -d "$PCL_DIR" ]]; then
-        wget "$PCL_URL"
-        tar -xf "$PCL_FILE.tar.gz"
-        rm -rf "$PCL_FILE.tar.gz"
-    fi
-    cd "$PCL_DIR"
-    mkdir -p build
-    cd build
-
-    PCL_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11"
-    #if [ -n "$CONTINUOUS_INTEGRATION" ]; then
-        # Disable everything unneeded for a faster build
-        PCL_CMAKE_ARGS="${PCL_CMAKE_ARGS} \
-        -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF \
-        -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF \
-        -DWITH_LIBUSB=OFF -DWITH_OPENGL=OFF -DWITH_OPENNI=OFF \
-        -DWITH_OPENNI2=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF -DWITH_VTK=OFF \
-        -DBUILD_CUDA=OFF -DBUILD_GPU=OFF -DBUILD_surface=OFF \
-        -DBUILD_ml=OFF -DBUILD_io=OFF -DBUILD_geometry=OFF \
-        -DBUILD_tracking=OFF"
-    #fi
-
-    cmake .. ${PCL_CMAKE_ARGS} > /dev/null
-
-    echo "Building $PCL_FILE"
-    make
-
-    sudo make install > /dev/null
-    echo "PCL installed successfully"
+elif [ $UBUNTU_VERSION == "14.04" ]; then
+    install_dependencies_14
+    sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/pcl
+    sudo apt-get -y update
+    sudo apt-get -y install -qq libpcl-all
 fi

--- a/scripts/install/pcl_install.bash
+++ b/scripts/install/pcl_install.bash
@@ -5,18 +5,20 @@ install_dependencies() {
     sudo apt-get -y install -qq \
         libboost-all-dev \
         libflann-dev \
-        libvtk6-dev \
         libeigen3-dev \
         libusb-1.0-0-dev \
-        tcl-vtk \
-        python-vtk \
-        libvtk-java
+	libvtk6 \
+	libvtk6-java \
+	python-vtk6 \
+	tcl-vtk6 \
+	libqt5opengl5
 }
 
 echo "Installing PCL ..."
 
 install_dependencies
 
+DEPS_DIR="/tmp/libwave_deps"
 PCL_VERSION='1.8.0'
 PCL_FILE="pcl-$PCL_VERSION"
 PCL_DIR="pcl-$PCL_FILE"
@@ -39,7 +41,7 @@ else
     cd build
 
     PCL_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11"
-    if [ -n "$CONTINUOUS_INTEGRATION" ]; then
+    #if [ -n "$CONTINUOUS_INTEGRATION" ]; then
         # Disable everything unneeded for a faster build
         PCL_CMAKE_ARGS="${PCL_CMAKE_ARGS} \
         -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF \
@@ -49,12 +51,12 @@ else
         -DBUILD_CUDA=OFF -DBUILD_GPU=OFF -DBUILD_surface=OFF \
         -DBUILD_ml=OFF -DBUILD_io=OFF -DBUILD_geometry=OFF \
         -DBUILD_tracking=OFF"
-    fi
+    #fi
 
     cmake .. ${PCL_CMAKE_ARGS} > /dev/null
 
     echo "Building $PCL_FILE"
-    make_with_progress -j4
+    make
 
     sudo make install > /dev/null
     echo "PCL installed successfully"

--- a/wave_matching/include/wave/matching/icp.hpp
+++ b/wave_matching/include/wave/matching/icp.hpp
@@ -15,6 +15,7 @@ typedef pcl::PointCloud<pcl::PointXYZ>::Ptr PCLPointCloud;
 class ICPMatcher : public Matcher<PCLPointCloud> {
  public:
     explicit ICPMatcher(float resolution);
+    ~ICPMatcher();
     void setRef(const PCLPointCloud &ref);
     void setTarget(const PCLPointCloud &target);
     bool match();

--- a/wave_matching/include/wave/matching/matcher.hpp
+++ b/wave_matching/include/wave/matching/matcher.hpp
@@ -15,6 +15,8 @@ class Matcher {
         resolution = -1;
     }
 
+    virtual ~Matcher() {}
+
     const Eigen::Affine3d &getResult() {
         return this->result;
     };

--- a/wave_matching/src/icp.cpp
+++ b/wave_matching/src/icp.cpp
@@ -31,6 +31,18 @@ ICPMatcher::ICPMatcher(float res) {
     this->icp.setEuclideanFitnessEpsilon(fit_eps);
 }
 
+ICPMatcher::~ICPMatcher() {
+    if (this->ref) {
+        this->ref.reset();
+    }
+    if (this->target) {
+        this->target.reset();
+    }
+    if (this->final) {
+        this->final.reset();
+    }
+}
+
 void ICPMatcher::setRef(const PCLPointCloud &ref) {
     if (this->resolution > 0) {
         this->filter.setInputCloud(ref);


### PR DESCRIPTION
This is to address issues #39 and #40. The vtk compiler warnings are because the version of pcl in the ubuntu repositories is 1.7.2 and looks for vtk 5.8 while the version of vtk in the ubuntu repositories is a mix of 5.8, 5.10, and 6. The components being complained about don't seem to be available in version 5.8. Fortunately vtk stands for visual toolkit, and we aren't using these features so these warnings are safe to ignore.

The pcl install script now changes for trusty or xenial.

Finally another warning about virtual destructors was resolved.