### PR TITLE
Install script: use ceres release 1.12.0

### DIFF
--- a/scripts/install/ceres_install.bash
+++ b/scripts/install/ceres_install.bash
@@ -2,6 +2,7 @@
 set -e  # exit on first error
 UBUNTU_VERSION=`lsb_release --release | cut -f2`
 SRC_PREFIX_PATH="/usr/local/src/"
+CERES_VERSION=1.12.0
 
 
 install_dependencies() {
@@ -27,6 +28,7 @@ install_ceres_solver() {
 
     # go into ceres-solver repo and prepare for build
     cd ceres-solver
+    git checkout tags/${CERES_VERSION}
     mkdir build
     cd build
     cmake ..


### PR DESCRIPTION
Currently we are pulling and building master, which sometimes causes issues.

The `CERES_VERSION` variable will have to be updated when we want to install a
newer release. (It is possible to check out the latest tag, but that includes
release candidate tags, so would need more logic, etc)