### PR TITLE
Add wave_containers to ci_run.bash

### DIFF
--- a/scripts/ci_run.bash
+++ b/scripts/ci_run.bash
@@ -17,6 +17,7 @@ run_module_tests() {
 # MAIN
 compile_libwave
 run_module_tests wave_controls
+run_module_tests wave_containers
 run_module_tests wave_geometry
 run_module_tests wave_kinematics
 run_module_tests wave_optimization


### PR DESCRIPTION
Temporary fix for #66.

(A permament fix would move the configuration of tests to run to CMake, so
the next module added doesn't have the same problem)