### PR TITLE
Add range operations to measurement containers

### DIFF
--- a/wave_containers/include/wave/containers/measurement_container.hpp
+++ b/wave_containers/include/wave/containers/measurement_container.hpp
@@ -61,8 +61,8 @@ struct measurement_container {
     struct sensor_key : member<T, decltype(T::sensor_id), &T::sensor_id> {};
 
     // Define a composite key which combines the above two keys
-    // This lets us search elements sorted by sensor id first, then time
-    struct sensor_and_time_key : composite_key<T, sensor_key, time_key> {};
+    // This lets us search elements sorted by time first, then  sensor id
+    struct sensor_and_time_key : composite_key<T, time_key, sensor_key> {};
 
     // These types are used as tags to retrieve each index after the
     // multi_index_container is generated
@@ -84,8 +84,16 @@ struct measurement_container {
     // This is the container type which can actually be used to make objects
     using type = boost::multi_index_container<T, indices, std::allocator<T>>;
 
-    // For convenience, get the type of the composite index, using its tag
+    // For convenience, get the type of some indices, using their tags
     using composite_type = typename type::template index<composite_index>::type;
+    using sensor_type = typename type::template index<sensor_index>::type;
+
+
+    // Define a view indexed by time, for complex searches
+    struct const_time_index
+      : indexed_by<ordered_unique<member<T, const TimeType, &T::time_point>>> {
+    };
+    using time_view = boost::multi_index_container<const T *, const_time_index>;
 };
 }  // namespace internal
 
@@ -123,12 +131,18 @@ class MeasurementContainer {
       typename internal::measurement_container<T>::composite_type::iterator;
     using const_iterator = typename internal::measurement_container<
       T>::composite_type::const_iterator;
+    using sensor_iterator =
+      typename internal::measurement_container<T>::sensor_type::iterator;
     using size_type = std::size_t;
 
     // Constructors
 
     /** Default construct an empty container */
     MeasurementContainer();
+
+    /** Construct the container with the contents of the range [first, last) */
+    template <typename InputIt>
+    MeasurementContainer(InputIt first, InputIt last);
 
     // Capacity
 
@@ -148,6 +162,15 @@ class MeasurementContainer {
      */
     std::pair<iterator, bool> insert(const MeasurementType &);
 
+    /** For each element of the range [first, last), inserts a Measurement if a
+     * measurement for the same time and sensor does not already exist.
+     *
+     * @param first, last iterators representing a valid range of Measurements,
+     * but not iterators into this container
+     */
+    template <typename InputIt>
+    void insert(InputIt first, InputIt last);
+
     /** Insert a Measurement constructed from the arguments if a measurement for
      * the same time and sensor does not already exist.
      *
@@ -161,7 +184,24 @@ class MeasurementContainer {
      *
      * @return the number of elements deleted.
      */
-    size_type erase(const TimeType &, const SensorIdType &);
+    size_type erase(const TimeType &t, const SensorIdType &s);
+
+    /** Delete the element at `position`
+     *
+     * @param position a valid dereferenceable iterator of this container
+     * @return An iterator pointing to the element following the deleted one, or
+     * `end()` if it was the last.
+     */
+    iterator erase(iterator position) noexcept;
+
+
+    /** Delete the elements in the range [first, last)
+     *
+     * @param first, last a valid range of this container
+     * @return `last`
+     */
+    iterator erase(iterator first, iterator last) noexcept;
+
 
     /** Delete all elements */
     void clear() noexcept;
@@ -169,7 +209,30 @@ class MeasurementContainer {
     // Retrieval
 
     /** Get the value of a measurement with corresponding time and sensor id */
-    const ValueType get(const TimeType &, const SensorIdType &) const;
+    ValueType get(const TimeType &t, const SensorIdType &s) const;
+
+    /** Get all measurements from the given sensor
+     *
+     * @return a pair of iterators representing the start and end of the range.
+     * If the range is empty, both iterators will be equal.
+     *
+     * @note because these iterators use the underlying ordered index of
+     * sensor_ids, they are not the same type as those from `begin()`,
+     * `getTimeWindow()`, etc.
+     */
+    std::pair<sensor_iterator, sensor_iterator> getAllFromSensor(
+      const SensorIdType &s) const noexcept;
+
+    /** Get all measurements between the given times.
+     *
+     * @param start, end an inclusive range of times, with start <= end
+     *
+     * @return a pair of iterators representing the start and end of the range.
+     * If the range is empty, both iterators will be equal.
+     */
+    std::pair<iterator, iterator> getTimeWindow(const TimeType &start,
+                                                const TimeType &end) const
+      noexcept;
 
     // Iterators
 
@@ -197,10 +260,23 @@ class MeasurementContainer {
 template <typename T>
 MeasurementContainer<T>::MeasurementContainer() {}
 
+/** Construct the container with the contents of a range */
+template <typename T>
+template <typename InputIt>
+MeasurementContainer<T>::MeasurementContainer(InputIt first, InputIt last) {
+    this->composite().insert(first, last);
+};
+
 template <typename T>
 std::pair<typename MeasurementContainer<T>::iterator, bool>
 MeasurementContainer<T>::insert(const MeasurementType &m) {
     return this->composite().insert(m);
+}
+
+template <typename T>
+template <typename InputIt>
+void MeasurementContainer<T>::insert(InputIt first, InputIt last) {
+    return this->composite().insert(first, last);
 }
 
 template <typename T>
@@ -220,7 +296,7 @@ template <typename T>
 typename MeasurementContainer<T>::size_type MeasurementContainer<T>::erase(
   const TimeType &t, const SensorIdType &s) {
     auto &composite = this->composite();
-    auto it = composite.find(boost::make_tuple(s, t));
+    auto it = composite.find(boost::make_tuple(t, s));
     if (it == composite.end()) {
         return 0;
     }
@@ -229,31 +305,93 @@ typename MeasurementContainer<T>::size_type MeasurementContainer<T>::erase(
 }
 
 template <typename T>
-const typename MeasurementContainer<T>::ValueType MeasurementContainer<T>::get(
+typename MeasurementContainer<T>::iterator MeasurementContainer<T>::erase(
+  iterator position) noexcept {
+    return this->composite().erase(position);
+}
+
+template <typename T>
+typename MeasurementContainer<T>::iterator MeasurementContainer<T>::erase(
+  iterator first, iterator last) noexcept {
+    return this->composite().erase(first, last);
+}
+
+template <typename T>
+typename MeasurementContainer<T>::ValueType MeasurementContainer<T>::get(
   const TimeType &t, const SensorIdType &s) const {
-    const auto &composite = this->composite();
+    // To interpolate measurements from one sensor only, we first extract all
+    // measurements from that sensor, then search by time. This method is based
+    // on one described here:
+    // http://www.boost.org/doc/libs/1_63_0/libs/multi_index/doc/examples.html#example6
 
-    // lower_bound is pointer to the first element >= key
-    auto i_next = composite.lower_bound(boost::make_tuple(s, t));
+    // Find all measurements from this sensor
+    const auto &sensor_index = this->storage.template get<
+      typename internal::measurement_container<T>::sensor_index>();
+    const auto sensor_it = sensor_index.equal_range(s);
 
-    // Pointer to the first element < key (since keys are unique)
-    auto i_prev = i_next;
-    --i_prev;
-
-    if (t == i_next->time_point && s == i_next->sensor_id) {
-        // Requested time exactly matches
-        return i_next->value;
+    // Construct a view, indexed by time, with only those measurements
+    auto time_view = typename internal::measurement_container<T>::time_view{};
+    for (auto it = sensor_it.first; it != sensor_it.second; ++it) {
+        time_view.insert(&*it);  // the view holds pointers to the measurements
     }
 
-    // The search looks at sensor_id first, then time. Must check both.
-    if (i_next == composite.end() || i_next == composite.begin() ||
-        s != i_next->sensor_id || s != i_prev->sensor_id) {
+    // find the first element with time >= t
+    auto i_next = time_view.lower_bound(t);
+
+    if (i_next == time_view.end()) {
         // Requested time is not between two measurements for this sensor
         throw std::out_of_range("MeasurementContainer::get");
     }
 
-    // Requested time is between two applicable measurements
-    return interpolate(*i_prev, *i_next, t);
+    const auto p_next = *i_next;
+
+    if (t == p_next->time_point) {
+        // Requested time exactly matches
+        return p_next->value;
+    }
+
+    // If no exact match, need at least one more measurement to interpolate
+    if (i_next == time_view.begin()) {
+        // Requested time is not between two measurements for this sensor
+        throw std::out_of_range("MeasurementContainer::get");
+    }
+
+    // Requested time is between two applicable measurements. Can interpolate.
+    // Get pointer to the first element < t (since keys are unique)
+    const auto i_prev = std::prev(i_next);
+    const auto p_prev = *i_prev;
+    return interpolate(*p_prev, *p_next, t);
+}
+
+template <typename T>
+std::pair<typename MeasurementContainer<T>::sensor_iterator,
+          typename MeasurementContainer<T>::sensor_iterator>
+MeasurementContainer<T>::getAllFromSensor(const SensorIdType &s) const
+  noexcept {
+    // Get the measurements sorted by sensor_id
+    const auto &sensor_index = this->storage.template get<
+      typename internal::measurement_container<T>::sensor_index>();
+
+    return sensor_index.equal_range(s);
+};
+
+template <typename T>
+std::pair<typename MeasurementContainer<T>::iterator,
+          typename MeasurementContainer<T>::iterator>
+MeasurementContainer<T>::getTimeWindow(const TimeType &start,
+                                       const TimeType &end) const noexcept {
+    // Consider a "backward" window empty
+    if (start > end) {
+        return {this->end(), this->end()};
+    }
+
+    // The composite index is already sorted by time first, thus it's enough to
+    // do a partial search. Find the start and end of the range.
+    const auto &composite = this->composite();
+    auto iter_begin = composite.lower_bound(boost::make_tuple(start));
+    auto iter_end = composite.upper_bound(boost::make_tuple(end));
+
+    return {iter_begin, iter_end};
 }
 
 template <typename T>

--- a/wave_containers/tests/containers/measurement_test.cpp
+++ b/wave_containers/tests/containers/measurement_test.cpp
@@ -253,7 +253,8 @@ TEST_F(FilledMeasurementContainer, getTimeWindowAll) {
     // Check case of window containing all measurements
     const auto t = this->t_start;
     auto res = this->m.getTimeWindow(t, t + seconds(99));
-    EXPECT_EQ(this->m.size(), std::distance(res.first, res.second));
+    EXPECT_EQ(static_cast<signed>(this->m.size()),
+              std::distance(res.first, res.second));
 
     for (int i = 0; res.first != res.second; ++i, ++res.first) {
         EXPECT_DOUBLE_EQ(this->inputs[i], res.first->value);
@@ -275,7 +276,6 @@ TEST_F(FilledMeasurementContainer, getTimeWindowSome) {
 
 TEST_F(FilledMeasurementContainer, getAllFromSensor) {
     // Check case of empty result
-    const auto t = this->t_start;
     auto res = this->m.getAllFromSensor(SomeSensors::S3);
     EXPECT_EQ(res.first, res.second);
 

--- a/wave_containers/tests/containers/measurement_test.cpp
+++ b/wave_containers/tests/containers/measurement_test.cpp
@@ -99,10 +99,10 @@ TEST(Utils_measurement, get_interpolated_other_sensors) {
     auto t2 = t1 + seconds(10);
     auto tmid = t1 + seconds(5);
 
-    m.emplace(t1, SomeSensors::S1, 10);
-    m.emplace(t2, SomeSensors::S1, 20);
-    m.emplace(t1, SomeSensors::S3, 70);
-    m.emplace(t2, SomeSensors::S3, 80);
+    m.emplace(t1, SomeSensors::S1, 10.);
+    m.emplace(t2, SomeSensors::S1, 20.);
+    m.emplace(t1, SomeSensors::S3, 70.);
+    m.emplace(t2, SomeSensors::S3, 80.);
 
     EXPECT_THROW(m.get(tmid, SomeSensors::S2), std::out_of_range);
 }

--- a/wave_containers/tests/containers/measurement_test.cpp
+++ b/wave_containers/tests/containers/measurement_test.cpp
@@ -10,6 +10,8 @@ enum class SomeSensors { S1, S2, S3 };
 // This is the measurement type used in these tests
 using TestMeasurement = Measurement<double, SomeSensors>;
 
+using std::chrono::seconds;
+
 TEST(Utils_measurement, insert) {
     MeasurementContainer<TestMeasurement> m;
     auto now = std::chrono::steady_clock::now();
@@ -55,22 +57,6 @@ TEST(Utils_measurement, capacity) {
     EXPECT_FALSE(m.empty());
 }
 
-TEST(Utils_measurement, erase) {
-    MeasurementContainer<TestMeasurement> m;
-
-    auto now = std::chrono::steady_clock::now();
-    m.emplace(now, SomeSensors::S1, 2.5);
-    ASSERT_EQ(1ul, m.size());
-
-    auto res = m.erase(now, SomeSensors::S2);
-    EXPECT_EQ(0ul, res);
-    EXPECT_EQ(1ul, m.size());
-
-    res = m.erase(now, SomeSensors::S1);
-    EXPECT_EQ(1ul, res);
-    EXPECT_EQ(0ul, m.size());
-}
-
 TEST(Utils_measurement, get) {
     MeasurementContainer<TestMeasurement> m;
 
@@ -87,8 +73,8 @@ TEST(Utils_measurement, get) {
 TEST(Utils_measurement, get_interpolated) {
     MeasurementContainer<TestMeasurement> m;
     auto t1 = std::chrono::steady_clock::now();
-    auto t2 = t1 + std::chrono::seconds(10);
-    auto tmid = t1 + std::chrono::seconds(5);
+    auto t2 = t1 + seconds(10);
+    auto tmid = t1 + seconds(5);
 
     auto v1 = 3.5, v2 = 8.0;
     m.emplace(t1, SomeSensors::S1, v1);
@@ -96,7 +82,7 @@ TEST(Utils_measurement, get_interpolated) {
 
     // Measurements with different id - expect no effect
     m.emplace(tmid, SomeSensors::S2, -100.);
-    m.emplace(t1 + std::chrono::seconds(6), SomeSensors::S2, -99.);
+    m.emplace(t1 + seconds(6), SomeSensors::S2, -99.);
 
     auto value_out = m.get(tmid, SomeSensors::S1);
 
@@ -110,8 +96,8 @@ TEST(Utils_measurement, get_interpolated_other_sensors) {
 
     MeasurementContainer<TestMeasurement> m;
     auto t1 = std::chrono::steady_clock::now();
-    auto t2 = t1 + std::chrono::seconds(10);
-    auto tmid = t1 + std::chrono::seconds(5);
+    auto t2 = t1 + seconds(10);
+    auto tmid = t1 + seconds(5);
 
     m.emplace(t1, SomeSensors::S1, 10);
     m.emplace(t2, SomeSensors::S1, 20);
@@ -121,30 +107,13 @@ TEST(Utils_measurement, get_interpolated_other_sensors) {
     EXPECT_THROW(m.get(tmid, SomeSensors::S2), std::out_of_range);
 }
 
+
 TEST(Utils_measurement, iterators) {
-    // Todo: not sure how to check that all iterator functionality works
     // Since I'm just wrapping internal iterators, just do a simple sanity check
     MeasurementContainer<TestMeasurement> m;
 
     EXPECT_EQ(m.begin(), m.end());
     EXPECT_EQ(m.cbegin(), m.cend());
-
-    for (auto i = 0; i < 5; ++i) {
-        auto now = std::chrono::steady_clock::now();
-        auto value_in = i * 1.1;
-        m.emplace(now, SomeSensors::S1, value_in);
-    }
-    ASSERT_EQ(5ul, m.size());
-
-    EXPECT_EQ(5, std::distance(m.begin(), m.end()));
-    EXPECT_EQ(5, std::distance(m.cbegin(), m.cend()));
-
-    auto expected = 0.0;
-    // Note the container supports range-based for loops
-    for (auto &v : m) {
-        EXPECT_DOUBLE_EQ(expected, v.value);
-        expected += 1.1;
-    }
 
     const MeasurementContainer<TestMeasurement> cm;
     EXPECT_EQ(cm.begin(), cm.end());
@@ -154,7 +123,7 @@ TEST(Utils_measurement, clear) {
     MeasurementContainer<TestMeasurement> m;
     auto now = std::chrono::steady_clock::now();
     for (auto i = 0; i < 5; ++i) {
-        m.emplace(now + std::chrono::seconds(i), SomeSensors::S1, 2.5);
+        m.emplace(now + seconds(i), SomeSensors::S1, 2.5);
     }
     ASSERT_EQ(5ul, m.size());
 
@@ -162,6 +131,161 @@ TEST(Utils_measurement, clear) {
 
     EXPECT_EQ(0ul, m.size());
     EXPECT_TRUE(m.empty());
+}
+
+/** Test fixture with sample data */
+class FilledMeasurementContainer : public ::testing::Test {
+ protected:
+    MeasurementContainer<TestMeasurement> m;
+    // Define some sample input measurements
+    const TimeType t_start = std::chrono::steady_clock::now();
+    const std::vector<double> inputs = {1.2, 10, 3.4, 25, 5.6, -7, 7.8, 0};
+
+
+    FilledMeasurementContainer() {
+        for (int i = 0; i < 4; ++i) {
+            auto t = this->t_start + seconds(i);
+            m.emplace(t, SomeSensors::S1, this->inputs[2 * i]);
+            m.emplace(t, SomeSensors::S2, this->inputs[2 * i + 1]);
+        }
+    }
+};
+
+TEST_F(FilledMeasurementContainer, eraseByKey) {
+    // Erase non-existent key
+    auto res = this->m.erase(this->t_start, SomeSensors::S3);
+    EXPECT_EQ(0ul, res);
+    EXPECT_EQ(this->inputs.size(), this->m.size());
+
+    // Erase existent key
+    res = this->m.erase(this->t_start, SomeSensors::S2);
+    EXPECT_EQ(1ul, res);
+    EXPECT_EQ(this->inputs.size() - 1, m.size());
+}
+
+TEST_F(FilledMeasurementContainer, eraseByPosition) {
+    // Erase existent position
+    auto b = this->m.begin();
+    auto res = this->m.erase(b);
+    EXPECT_EQ(++b, res);
+    EXPECT_EQ(this->inputs.size() - 1, m.size());
+    EXPECT_DOUBLE_EQ(this->inputs[1], this->m.begin()->value);
+
+    // Erase last position
+    auto end = this->m.end();
+    res = this->m.erase(--end);
+    EXPECT_EQ(this->m.end(), res);
+    EXPECT_EQ(this->inputs.size() - 2, m.size());
+}
+
+TEST_F(FilledMeasurementContainer, eraseByRange) {
+    auto a = std::next(this->m.begin(), 1);
+    auto b = std::next(this->m.begin(), 3);
+    auto res = this->m.erase(a, b);
+    EXPECT_EQ(b, res);
+    EXPECT_EQ(this->inputs.size() - 2, m.size());
+    EXPECT_DOUBLE_EQ(this->inputs[0], this->m.begin()->value);
+    EXPECT_DOUBLE_EQ(this->inputs[3], b->value);
+}
+
+TEST_F(FilledMeasurementContainer, iterators) {
+    // Since I'm just wrapping internal iterators, just do a simple sanity check
+    ASSERT_EQ(8ul, this->m.size());
+
+    EXPECT_EQ(8, std::distance(this->m.begin(), this->m.end()));
+    EXPECT_EQ(8, std::distance(this->m.cbegin(), this->m.cend()));
+
+    // Note the container supports range-based for loops
+    auto i = 0;
+    for (auto &v : this->m) {
+        EXPECT_DOUBLE_EQ(this->inputs[i++], v.value);
+    }
+}
+
+TEST_F(FilledMeasurementContainer, constructFromRange) {
+    auto first = this->m.begin();
+    auto last = this->m.end();
+    auto m2 = MeasurementContainer<TestMeasurement>(first, last);
+
+    // Check that the copy has the same content as the original
+    ASSERT_EQ(this->m.size(), m2.size());
+    auto it = m2.begin();
+    while (it != m2.end()) {
+        EXPECT_EQ(first++->value, it++->value);
+    }
+
+    // Check that the copy is independent of the original
+    this->m.erase(this->t_start, SomeSensors::S1);
+    EXPECT_NE(this->m.size(), m2.size());
+}
+
+TEST_F(FilledMeasurementContainer, insertRange) {
+    auto a = std::next(this->m.begin(), 1);
+    auto b = std::next(this->m.begin(), 3);
+
+    auto m2 = MeasurementContainer<TestMeasurement>{};
+    m2.insert(a, b);
+    EXPECT_EQ(2ul, m2.size());
+
+    auto it = m2.begin();
+    EXPECT_DOUBLE_EQ(this->inputs[1], it->value);
+    EXPECT_DOUBLE_EQ(this->inputs[2], (++it)->value);
+
+    m2.insert(a, ++b);
+    EXPECT_EQ(3ul, m2.size());
+}
+
+TEST_F(FilledMeasurementContainer, getTimeWindowEmpty) {
+    // Check case of window with no measurements
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t - seconds(2), t - seconds(1));
+    EXPECT_EQ(res.first, res.second);
+}
+
+TEST_F(FilledMeasurementContainer, getTimeWindowBackwards) {
+    // Check case of backwards window
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t + seconds(10), t);
+    EXPECT_EQ(res.first, res.second);
+}
+
+TEST_F(FilledMeasurementContainer, getTimeWindowAll) {
+    // Check case of window containing all measurements
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t, t + seconds(99));
+    EXPECT_EQ(this->m.size(), std::distance(res.first, res.second));
+
+    for (int i = 0; res.first != res.second; ++i, ++res.first) {
+        EXPECT_DOUBLE_EQ(this->inputs[i], res.first->value);
+    }
+}
+
+TEST_F(FilledMeasurementContainer, getTimeWindowSome) {
+    // Check case of window containing some measurements
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t + seconds(1), t + seconds(2));
+    EXPECT_EQ(4u, std::distance(res.first, res.second));
+
+    const auto expected = std::vector<double>{3.4, 25, 5.6, -7};
+
+    for (int i = 0; res.first != res.second; ++i, ++res.first) {
+        EXPECT_DOUBLE_EQ(expected[i], res.first->value);
+    }
+}
+
+TEST_F(FilledMeasurementContainer, getAllFromSensor) {
+    // Check case of empty result
+    const auto t = this->t_start;
+    auto res = this->m.getAllFromSensor(SomeSensors::S3);
+    EXPECT_EQ(res.first, res.second);
+
+    // Check case of filled result
+    res = this->m.getAllFromSensor(SomeSensors::S1);
+    EXPECT_EQ(4, std::distance(res.first, res.second));
+    const auto expected = std::vector<double>{1.2, 3.4, 5.6, 7.8};
+    for (int i = 0; res.first != res.second; ++i, ++res.first) {
+        EXPECT_DOUBLE_EQ(expected[i], res.first->value);
+    }
 }
 
 }  // namespace wave


### PR DESCRIPTION
Continue #41

Add a number of methods working with iterators to MeasurementContainer, to
complete the interface and help with next work (dealing with ranges of landmarks).

New methods:
* getTimeWindow(): get all measurements between two times
* getAllFromSensor(): get all measurements from given sensor id
* constructor taking iterators: make new container with contents of a range
* erase() taking iterators: delete measurements in a range
* insert() taking iterators: insert contents of a range

These can be combined to, for example, copy a range of measurements to another
MeasurementConatiner or to a std::vector.

To help implement the above:
* change underlying sort order
* refactor get() interpolation implementation

Previously, the container was sorted an odd way (sensor id first, then time)
which made this method awkward.  Refactor to sort by time first, then sensor
id, and implement the "complex search" method described at
http://www.boost.org/doc/libs/1_63_0/libs/multi_index/doc/examples.html#example6
for get().
