### PR TITLE
Add landmark measurement container

### DIFF
--- a/wave_containers/CMakeLists.txt
+++ b/wave_containers/CMakeLists.txt
@@ -7,8 +7,10 @@ FIND_PACKAGE(Eigen3 REQUIRED)
 # INCLUDES
 INCLUDE_DIRECTORIES(
     include
-    ${Eigen3_DIRECTORY}
+    ${EIGEN3_INCLUDE_DIR}
 )
 
 # UNIT TESTS
-WAVE_ADD_TEST(${PROJECT_NAME}_tests tests/containers/measurement_test.cpp)
+WAVE_ADD_TEST(${PROJECT_NAME}_tests
+    tests/containers/measurement_test.cpp
+    tests/containers/landmark_measurement_test.cpp)

--- a/wave_containers/include/wave/containers/landmark_measurement.hpp
+++ b/wave_containers/include/wave/containers/landmark_measurement.hpp
@@ -1,0 +1,55 @@
+/**
+ * @file Specialized measurement type for landmark observations
+ * @ingroup containers
+ */
+#ifndef WAVE_CONTAINERS_LANDMARK_MEASUREMENT_HPP
+#define WAVE_CONTAINERS_LANDMARK_MEASUREMENT_HPP
+
+#include "wave/utils/math.hpp"
+
+namespace wave {
+/** @addtogroup containers
+ *  @{ */
+
+/** The integral type used to track a landmark across multiple measurements
+ *
+ * @todo: This is a weak typedef; consider a strong typedef using phantom types.
+ */
+using LandmarkId = std::size_t;
+using TimeType = std::chrono::steady_clock::time_point;
+
+/** Storage type for a landmark measurement as a 2D position.
+ *
+ * Presumably the landmark measurement has been extracted from a camera image,
+ * but it is now a separate entity with no record of which camera image it came
+ * from.
+ *
+ * This class template is similar to `Measurement`, with an additional member:
+ * `landmark_id`, which represents a unique ID used for tracking a single
+ * landmark across multiple images.
+ *
+ * The measurement value is 2D vector, representing the pixel position of the
+ * landmark (u, v).
+ *
+ * @tparam SensorIdType The enum or integral type used to identify camera
+ * sensors.
+ */
+template <typename SensorIdType>
+struct LandmarkMeasurement {
+    TimeType time_point;
+    SensorIdType sensor_id;
+    LandmarkId landmark_id;
+    Vec2 value;
+
+    LandmarkMeasurement(const TimeType &t,
+                        const SensorIdType &s,
+                        const LandmarkId &id,
+                        const Vec2 &v)
+        : time_point{t}, sensor_id{s}, landmark_id{id}, value{v} {}
+};
+
+
+/** @} end of group */
+}  // namespace wave
+
+#endif  // WAVE_CONTAINERS_LANDMARK_MEASUREMENT_HPP

--- a/wave_containers/include/wave/containers/landmark_measurement_container.hpp
+++ b/wave_containers/include/wave/containers/landmark_measurement_container.hpp
@@ -1,0 +1,546 @@
+/**
+ * @file
+ * Specialized measurement container for landmark observations
+ */
+#ifndef WAVE_CONTAINERS_LANDMARK_MEASUREMENT_CONTAINER_HPP
+#define WAVE_CONTAINERS_LANDMARK_MEASUREMENT_CONTAINER_HPP
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/version.hpp>
+#include <iterator>
+#include <chrono>
+#include <algorithm>
+
+namespace wave {
+/** @addtogroup containers
+ *  @{ */
+
+
+using TimeType = std::chrono::steady_clock::time_point;
+
+/** Internal implementation details - for developers only */
+namespace internal {
+
+using boost::multi_index::member;
+using boost::multi_index::indexed_by;
+using boost::multi_index::ordered_unique;
+using boost::multi_index::ordered_non_unique;
+using boost::multi_index::composite_key;
+using boost::multi_index::tag;
+
+/**
+ * The internal::landmark_container<T> holds all the type definitions
+ * required for a multi_index_container holding measurements of type T.
+ *
+ * See `wave::internal::measurement_container`.
+ */
+template <typename T>
+struct landmark_container {
+    // First, define which members of the Measurement object are used as keys
+    struct time_key : member<T, TimeType, &T::time_point> {};
+    struct sensor_key : member<T, decltype(T::sensor_id), &T::sensor_id> {};
+    struct landmark_key : member<T, decltype(T::landmark_id), &T::landmark_id> {
+    };
+
+    // Define a composite key which combines the above three keys
+    // This lets us search elements sorted by time, then sensor id, then
+    // landmark ID
+    struct combined_key : composite_key<T, time_key, sensor_key, landmark_key> {
+    };
+    struct sensor_composite_key
+      : composite_key<T, sensor_key, time_key, landmark_key> {};
+
+    // These types are used as tags to retrieve each index after the
+    // multi_index_container is generated
+    struct time_index {};
+    struct sensor_index {};
+    struct sensor_composite_index {};
+    struct landmark_index {};
+    struct composite_index {};
+
+    // Define an index for each key. Each index will be accessible via its tag
+    struct indices
+      : indexed_by<
+          ordered_non_unique<tag<time_index>, time_key>,
+          ordered_non_unique<tag<sensor_index>, sensor_key>,
+          ordered_non_unique<tag<landmark_index>, landmark_key>,
+          ordered_unique<tag<composite_index>, combined_key>,
+          ordered_unique<tag<sensor_composite_index>, sensor_composite_key>> {};
+
+    // Finally, define the multi_index_container type.
+    // This is the container type which can actually be used to make objects
+    using type = boost::multi_index_container<T, indices, std::allocator<T>>;
+
+    // For convenience, get the type of the indices, using their tags
+    using composite_type = typename type::template index<composite_index>::type;
+    using time_type = typename type::template index<time_index>::type;
+    using sensor_composite_type =
+      typename type::template index<sensor_composite_index>::type;
+    using landmark_type = typename type::template index<landmark_index>::type;
+
+    // Define a view indexed by time, for complex searches
+    struct const_time_index
+      : indexed_by<
+          ordered_non_unique<member<T, const TimeType, &T::time_point>>> {};
+    using time_view = boost::multi_index_container<const T *, const_time_index>;
+};
+}  // namespace internal
+
+/** Container which stores landmark measurements.
+ *
+ * @tparam T is the stored measurement type. The `LandmarkMeasurement` class
+ * template is designed to be used here.
+ *
+ * However, any class can be used that has the following public members:
+ *   - `time_point` (of type \c wave::TimeType)
+ *   - `sensor_id` (any type sortable by \c std::less)
+ *   - `landmark_id` (any type sortable by \c std::less)
+ *   - `value` (any type)
+ */
+template <typename T>
+class LandmarkMeasurementContainer {
+ public:
+    // Types
+
+    /** Alias for the template parameter, giving the type of measurement stored
+     * in this container */
+    using MeasurementType = T;
+    /** Alias for the measurement's value.
+     * Note this does *not* correspond to a typical container's value_type. */
+    using ValueType = decltype(MeasurementType::value);
+    /** Alias for the type of the sensor id */
+    using SensorIdType = decltype(MeasurementType::sensor_id);
+    /** Alias for the type of the landmark id */
+    using LandmarkIdType = decltype(MeasurementType::landmark_id);
+    /** A vector representing landmark / feature measurements across images */
+    using Track = std::vector<MeasurementType>;
+
+
+    using iterator =
+      typename internal::landmark_container<T>::composite_type::iterator;
+    using const_iterator =
+      typename internal::landmark_container<T>::composite_type::const_iterator;
+    using sensor_iterator =
+      typename internal::landmark_container<T>::sensor_composite_type::iterator;
+    using size_type = std::size_t;
+
+    // Constructors
+
+    /** Default construct an empty container */
+    LandmarkMeasurementContainer();
+
+    /** Construct the container with the contents of the range [first, last) */
+    template <typename InputIt>
+    LandmarkMeasurementContainer(InputIt first, InputIt last);
+
+    // Capacity
+
+    /** Return true if the container has no elements. */
+    bool empty() const noexcept;
+
+    /** Return the number of elements in the container. */
+    size_type size() const noexcept;
+
+    // Modifiers
+
+    /** Insert a Measurement if a measurement for the same time and sensor does
+     * not already exist.
+     *
+     * @return a pair p. If and only if insertion occurred, p.second is true and
+     * p.first points to the element inserted.
+     */
+    std::pair<iterator, bool> insert(const MeasurementType &m);
+
+    /** For each element of the range [first, last), inserts a Measurement if a
+     * measurement for the same time and sensor does not already exist.
+     *
+     * @param first, last iterators representing a valid range of Measurements,
+     * but not iterators into this container
+     */
+    template <typename InputIt>
+    void insert(InputIt first, InputIt last);
+
+    /** Insert a Measurement constructed from the arguments if a measurement for
+     * the same time and sensor does not already exist.
+     *
+     * @return a pair p. If and only if insertion occurred, p.second is true and
+     * p.first points to the element inserted.
+     */
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args &&... args);
+
+    /** Delete the element with the matching time, sensor, and landmark id if
+     * one exists.
+     *
+     * @return the number of elements deleted.
+     */
+    size_type erase(const TimeType &t, SensorIdType s, LandmarkIdType id);
+
+    /** Delete the element at `position`
+     *
+     * @param position a valid dereferenceable iterator of this container
+     * @return An iterator pointing to the element following the deleted one, or
+     * `end()` if it was the last.
+     */
+    iterator erase(iterator position) noexcept;
+
+
+    /** Delete the elements in the range [first, last)
+     *
+     * @param first, last a valid range of this container
+     * @return `last`
+     */
+    iterator erase(iterator first, iterator last) noexcept;
+
+    /** Delete all elements */
+    void clear() noexcept;
+
+    // Retrieval
+
+    /** Gets the value of a landmark measurement.
+     *
+     * @throw std::out_of_range if a measurement with exactly matching time,
+     * sensor, and landmark id does not exist.
+     *
+     * No interpolation is performed.
+     */
+    ValueType get(const TimeType &t, SensorIdType s, LandmarkIdType id) const;
+
+    /** Get all measurements from the given sensor
+     *
+     * @return a pair of iterators representing the start and end of the range.
+     * If the range is empty, both iterators will be equal.
+     *
+     * @note because these iterators use the underlying ordered index of
+     * sensor_ids, they are not the same type as those from `begin()`,
+     * `getTimeWindow()`, etc.
+     */
+    std::pair<sensor_iterator, sensor_iterator> getAllFromSensor(
+      const SensorIdType &s) const noexcept;
+
+    /** Get all measurements between the given times.
+     *
+     * @param start, end an inclusive range of times, with start <= end
+     *
+     * @return a pair of iterators representing the start and end of the range.
+     * If the range is empty, both iterators will be equal.
+     */
+    std::pair<iterator, iterator> getTimeWindow(const TimeType &start,
+                                                const TimeType &end) const
+      noexcept;
+
+    /** Get a list of all unique landmark IDs in the container */
+    std::vector<LandmarkIdType> getLandmarkIDs() const;
+
+    /** Get unique landmark IDs with measurements in the time window */
+    std::vector<LandmarkIdType> getLandmarkIDsInWindow(
+      const TimeType &start, const TimeType &end) const;
+
+    /** Get a sequence of measurements of a landmark from one sensor
+     * @return a vector of landmark measurements sorted by time
+     *
+     */
+    Track getTrack(const SensorIdType &s, const LandmarkIdType &id) const
+      noexcept;
+
+    /** Get a sequnce of measurements of a landmark from one sensor, in the
+     * given
+     * time window.
+     *
+     * @return a vector of landmark measurements sorted by time
+      */
+    Track getTrackInWindow(const SensorIdType &s,
+                           const LandmarkIdType &id,
+                           const TimeType &start,
+                           const TimeType &end) const noexcept;
+
+    // Iterators
+
+    iterator begin() noexcept;
+    iterator end() noexcept;
+    const_iterator begin() const noexcept;
+    const_iterator end() const noexcept;
+    const_iterator cbegin() const noexcept;
+    const_iterator cend() const noexcept;
+
+ protected:
+    using composite_type =
+      typename internal::landmark_container<T>::composite_type;
+
+    // Helper to get the composite index
+    composite_type &composite() noexcept;
+    const composite_type &composite() const noexcept;
+
+    // Internal multi_index_container
+    typename internal::landmark_container<T>::type storage;
+};
+
+template <typename T>
+LandmarkMeasurementContainer<T>::LandmarkMeasurementContainer() {}
+
+
+template <typename T>
+template <typename InputIt>
+LandmarkMeasurementContainer<T>::LandmarkMeasurementContainer(InputIt first,
+                                                              InputIt last) {
+    this->composite().insert(first, last);
+};
+
+template <typename T>
+std::pair<typename LandmarkMeasurementContainer<T>::iterator, bool>
+LandmarkMeasurementContainer<T>::insert(const MeasurementType &m) {
+    return this->composite().insert(m);
+}
+
+template <typename T>
+template <typename InputIt>
+void LandmarkMeasurementContainer<T>::insert(InputIt first, InputIt last) {
+    return this->composite().insert(first, last);
+}
+
+template <typename T>
+template <typename... Args>
+std::pair<typename LandmarkMeasurementContainer<T>::iterator, bool>
+LandmarkMeasurementContainer<T>::emplace(Args &&... args) {
+// Support Boost.MultiIndex <= 1.54, which does not have emplace()
+#if BOOST_VERSION < 105500
+    return this->composite().insert(
+      MeasurementType{std::forward<Args>(args)...});
+#else
+    return this->composite().emplace(std::forward<Args>(args)...);
+#endif
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::size_type
+LandmarkMeasurementContainer<T>::erase(const TimeType &t,
+                                       SensorIdType s,
+                                       LandmarkIdType id) {
+    auto &composite = this->composite();
+    auto it = composite.find(boost::make_tuple(t, s, id));
+    if (it == composite.end()) {
+        return 0;
+    }
+    composite.erase(it);
+    return 1;
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::iterator
+LandmarkMeasurementContainer<T>::erase(iterator position) noexcept {
+    return this->composite().erase(position);
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::iterator
+LandmarkMeasurementContainer<T>::erase(iterator first, iterator last) noexcept {
+    return this->composite().erase(first, last);
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::ValueType
+LandmarkMeasurementContainer<T>::get(const TimeType &t,
+                                     SensorIdType s,
+                                     LandmarkIdType id) const {
+    const auto &composite = this->composite();
+
+    auto iter = composite.find(boost::make_tuple(t, s, id));
+    if (iter == composite.end()) {
+        // Requested key is not in this container
+        throw std::out_of_range("LandmarkMeasurementContainer::get");
+    }
+    return iter->value;
+}
+
+template <typename T>
+std::pair<typename LandmarkMeasurementContainer<T>::sensor_iterator,
+          typename LandmarkMeasurementContainer<T>::sensor_iterator>
+LandmarkMeasurementContainer<T>::getAllFromSensor(const SensorIdType &s) const
+  noexcept {
+    // Get the measurements sorted by sensor_id
+    const auto &sensor_composite_index = this->storage.template get<
+      typename internal::landmark_container<T>::sensor_composite_index>();
+
+    return sensor_composite_index.equal_range(s);
+};
+
+template <typename T>
+std::pair<typename LandmarkMeasurementContainer<T>::iterator,
+          typename LandmarkMeasurementContainer<T>::iterator>
+LandmarkMeasurementContainer<T>::getTimeWindow(const TimeType &start,
+                                               const TimeType &end) const
+  noexcept {
+    // Consider a "backward" window empty
+    if (start > end) {
+        return {this->end(), this->end()};
+    }
+
+    // The composite index is already sorted by time first, thus it's enough to
+    // do a partial search. Find the start and end of the range.
+    const auto &composite = this->composite();
+    auto iter_begin = composite.lower_bound(boost::make_tuple(start));
+    auto iter_end = composite.upper_bound(boost::make_tuple(end));
+
+    return {iter_begin, iter_end};
+}
+
+template <typename T>
+std::vector<typename LandmarkMeasurementContainer<T>::LandmarkIdType>
+LandmarkMeasurementContainer<T>::getLandmarkIDs() const {
+    return this->getLandmarkIDsInWindow(TimeType::min(), TimeType::max());
+}
+
+template <typename T>
+std::vector<typename LandmarkMeasurementContainer<T>::LandmarkIdType>
+LandmarkMeasurementContainer<T>::getLandmarkIDsInWindow(
+  const TimeType &start, const TimeType &end) const {
+    // Use the index sorted by landmark id
+    const auto &landmark_index = this->storage.template get<
+      typename internal::landmark_container<T>::landmark_index>();
+    auto unique_ids = std::vector<LandmarkIdType>{};
+
+    // Iterate over all measurements sorted by time, first then landmark_id.
+    // Copy landmark ids into a vector, skipping consecutive equal elements and
+    // elements outside the desired time window.
+    for (auto &meas : landmark_index) {
+        if (unique_ids.empty() || meas.landmark_id != unique_ids.back()) {
+            if (meas.time_point >= start && meas.time_point <= end) {
+                unique_ids.push_back(meas.landmark_id);
+            }
+        }
+    }
+
+    // Note there are other ways to do this, e.g. keeping another index, or
+    // performing a "complex search" by generating a view. Pending performance
+    // analysis, this method seems simplest.
+
+    return unique_ids;
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::Track
+LandmarkMeasurementContainer<T>::getTrack(const SensorIdType &s,
+                                          const LandmarkIdType &id) const
+  noexcept {
+    return this->getTrackInWindow(s, id, TimeType::min(), TimeType::max());
+};
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::Track
+LandmarkMeasurementContainer<T>::getTrackInWindow(const SensorIdType &s,
+                                                  const LandmarkIdType &id,
+                                                  const TimeType &start,
+                                                  const TimeType &end) const
+  noexcept {
+    // Consider a "backwards" window empty
+    if (start >= end) {
+        return Track{};
+    }
+
+    const auto &landmark_index = this->storage.template get<
+      typename internal::landmark_container<T>::landmark_index>();
+
+    // Get all measurements with desired landmark id
+    const auto res = landmark_index.equal_range(id);
+
+    // We need to get a track sorted by time, but landmark_index is not.
+    // Construct a view, indexed by time, with only those measurements
+    //
+    // This method is based on one described here:
+    // http://www.boost.org/doc/libs/1_63_0/libs/multi_index/doc/examples.html#example6
+    //
+    // While iterating, pick the measurements with desired sensor_id
+    auto time_view = typename internal::landmark_container<T>::time_view{};
+    for (auto it = res.first; it != res.second; ++it) {
+        if (it->sensor_id == s) {
+            // insert a pointer to the measurement
+            time_view.insert(&*it);
+        }
+    }
+
+    // Narrow down to the desired time window
+    const auto iter_begin = time_view.lower_bound(start);
+    const auto iter_end = time_view.upper_bound(end);
+
+    // Build a vector holding copies of the measurements
+    // Remember time_view holds pointers, so we can't copy it directly
+    auto track = Track{};
+    for (auto it = iter_begin; it != iter_end; ++it) {
+        track.push_back(**it);
+    }
+    return track;
+};
+
+template <typename T>
+bool LandmarkMeasurementContainer<T>::empty() const noexcept {
+    return this->composite().empty();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::size_type
+LandmarkMeasurementContainer<T>::size() const noexcept {
+    return this->composite().size();
+}
+
+template <typename T>
+void LandmarkMeasurementContainer<T>::clear() noexcept {
+    return this->composite().clear();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::iterator
+LandmarkMeasurementContainer<T>::begin() noexcept {
+    return this->composite().begin();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::iterator
+LandmarkMeasurementContainer<T>::end() noexcept {
+    return this->composite().end();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::const_iterator
+LandmarkMeasurementContainer<T>::begin() const noexcept {
+    return this->composite().begin();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::const_iterator
+LandmarkMeasurementContainer<T>::end() const noexcept {
+    return this->composite().end();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::const_iterator
+LandmarkMeasurementContainer<T>::cbegin() const noexcept {
+    return this->composite().cbegin();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::const_iterator
+LandmarkMeasurementContainer<T>::cend() const noexcept {
+    return this->composite().cend();
+}
+
+template <typename T>
+typename LandmarkMeasurementContainer<T>::composite_type &
+LandmarkMeasurementContainer<T>::composite() noexcept {
+    return this->storage.template get<
+      typename internal::landmark_container<T>::composite_index>();
+}
+
+template <typename T>
+const typename LandmarkMeasurementContainer<T>::composite_type &
+LandmarkMeasurementContainer<T>::composite() const noexcept {
+    return this->storage.template get<
+      typename internal::landmark_container<T>::composite_index>();
+}
+
+/** @} end of group */
+}  // namespace wave
+
+#endif  // WAVE_CONTAINERS_LANDMARK_MEASUREMENT_CONTAINER_HPP

--- a/wave_containers/tests/containers/landmark_measurement_test.cpp
+++ b/wave_containers/tests/containers/landmark_measurement_test.cpp
@@ -1,0 +1,472 @@
+#include "wave/wave_test.hpp"
+
+#include "wave/containers/landmark_measurement_container.hpp"
+#include "wave/containers/landmark_measurement.hpp"
+
+namespace wave {
+
+using std::chrono::seconds;
+
+enum class CameraSensors { Left = 0, Right = 1, Top = 2 };
+
+// This is the measurement type used in these tests
+using TestLandmarkMeasurement = LandmarkMeasurement<CameraSensors>;
+using TestContainer = LandmarkMeasurementContainer<TestLandmarkMeasurement>;
+
+TEST(LandmarkContainer, insert) {
+    auto now = std::chrono::steady_clock::now();
+    auto val = Vec2{1.2, 3.4};
+    auto landmark_id = std::size_t{1};
+    auto meas =
+      TestLandmarkMeasurement{now, CameraSensors::Left, landmark_id, val};
+    auto m = TestContainer{};
+
+    auto res = m.insert(meas);
+
+    EXPECT_EQ(1ul, m.size());
+    EXPECT_TRUE(res.second);
+
+    // Insert the same thing
+    auto res2 = m.insert(meas);
+    EXPECT_FALSE(res2.second);
+    EXPECT_EQ(res.first, res2.first);
+}
+
+TEST(LandmarkContainer, emplace) {
+    auto m = TestContainer{};
+    auto now = std::chrono::steady_clock::now();
+    auto res = m.emplace(now, CameraSensors::Left, 1, Vec2{1.2, 3.4});
+
+    EXPECT_EQ(1ul, m.size());
+    EXPECT_TRUE(res.second);
+
+    // Insert the same thing
+    auto res2 = m.emplace(now, CameraSensors::Left, 1, Vec2{2.3, 4.5});
+    EXPECT_FALSE(res2.second);
+    EXPECT_EQ(res.first, res2.first);
+}
+
+TEST(LandmarkContainer, capacity) {
+    auto m = TestContainer{};
+    auto now = std::chrono::steady_clock::now();
+
+    EXPECT_EQ(0ul, m.size());
+    EXPECT_TRUE(m.empty());
+
+    m.emplace(now, CameraSensors::Left, 1, Vec2{1.2, 3.4});
+    EXPECT_EQ(1ul, m.size());
+    EXPECT_FALSE(m.empty());
+}
+
+TEST(LandmarkContainer, erase) {
+    auto m = TestContainer{};
+    auto now = std::chrono::steady_clock::now();
+
+    m.emplace(now, CameraSensors::Left, 1, Vec2{1.2, 3.4});
+    ASSERT_EQ(1ul, m.size());
+
+    auto res = m.erase(now, CameraSensors::Right, 1);
+    EXPECT_EQ(0ul, res);
+    EXPECT_EQ(1ul, m.size());
+
+    res = m.erase(now, CameraSensors::Left, 1);
+    EXPECT_EQ(1ul, res);
+    EXPECT_EQ(0ul, m.size());
+}
+
+TEST(LandmarkContainer, get) {
+    auto m = TestContainer{};
+    auto now = std::chrono::steady_clock::now();
+    auto value_in = Vec2{1.2, 3.4};
+    m.emplace(now, CameraSensors::Left, 1, value_in);
+
+    auto value_out = m.get(now, CameraSensors::Left, 1);
+
+    EXPECT_PRED2(VectorsNear, value_in, value_out);
+}
+
+TEST(LandmarkContainer, iterators) {
+    // Since I'm just wrapping internal iterators, just do a simple sanity check
+    auto m = TestContainer{};
+
+    EXPECT_EQ(m.begin(), m.end());
+    EXPECT_EQ(m.cbegin(), m.cend());
+
+    for (auto i = 0; i < 5; ++i) {
+        auto now = std::chrono::steady_clock::now();
+        auto value_in = Vec2{i * 1.1, 0};
+        m.emplace(now, CameraSensors::Left, 1, value_in);
+    }
+    ASSERT_EQ(5ul, m.size());
+    EXPECT_EQ(5, std::distance(m.begin(), m.end()));
+    EXPECT_EQ(5, std::distance(m.cbegin(), m.cend()));
+
+    auto expected = Vec2{0, 0};
+    // Note the container supports range-based for loops
+    for (auto &v : m) {
+        EXPECT_PRED2(VectorsNear, expected, v.value);
+        expected(0) += 1.1;
+    }
+
+    const auto cm = TestContainer{};
+    EXPECT_EQ(cm.begin(), cm.end());
+}
+
+TEST(LandmarkContainer, clear) {
+    auto m = TestContainer{};
+    auto now = std::chrono::steady_clock::now();
+    auto value_in = Vec2{1.2, 3.4};
+    for (auto i = 0; i < 5; ++i) {
+        m.emplace(now, CameraSensors::Left, i, value_in);
+    }
+    ASSERT_EQ(5ul, m.size());
+
+    m.clear();
+
+    EXPECT_EQ(0ul, m.size());
+    EXPECT_TRUE(m.empty());
+}
+
+
+TEST(LandmarkContainer, getLandmarkIDs) {
+    auto m = TestContainer{};
+    auto ids = m.getLandmarkIDs();
+    EXPECT_TRUE(ids.empty());
+}
+
+/** Test fixture with sample data */
+class FilledLandmarkContainer : public ::testing::Test {
+ protected:
+    TestContainer m;
+    // Define some sample input measurements
+    const TimeType t_start = std::chrono::steady_clock::now();
+    const std::vector<std::vector<LandmarkId>> input_ids_l = {
+      {2}, {2}, {3, 4, 2}, {2, 5, 3}, {6}, {1}, {3}};
+    const std::vector<std::vector<LandmarkId>> input_ids_r = {
+      {1}, {}, {4, 2}, {4, 5}, {25, 1}, {}, {4}};
+    // generated sample values
+    std::vector<std::map<LandmarkId, Vec2>> inputs_l{input_ids_l.size()};
+    std::vector<std::map<LandmarkId, Vec2>> inputs_r{input_ids_r.size()};
+
+    // values sorted as expected (time, then sensor, then landmark id)
+    std::vector<Vec2> expected_values;
+    std::vector<Vec2> input_values_l;
+    std::vector<Vec2> input_values_r;
+    FilledLandmarkContainer() {
+        // Generate inputs and fill container. Follow a pattern for debugging
+        assert(7ul == input_ids_r.size());
+        assert(7ul == input_ids_r.size());
+        // Insert the measurements out-of-order by time, to ensure methods
+        // always return output sorted by time.
+        auto insert_order = std::vector<int>{1, 5, 2, 6, 4, 0, 3};
+
+        for (auto i = 0ul; i < input_ids_l.size(); ++i) {
+            auto k = insert_order[i];
+            auto t = this->t_start + seconds(k);
+            for (auto id : this->input_ids_l[k]) {
+                Vec2 val = Vec2::Ones() * (k + id / 10.0);
+                this->m.emplace(t, CameraSensors::Left, id, val);
+                this->inputs_l[k][id] = val;
+            }
+            for (auto id : this->input_ids_r[k]) {
+                Vec2 val = Vec2::Ones() * (10 + k + id / 10.0);
+                this->m.emplace(t, CameraSensors::Right, id, val);
+                this->inputs_r[k][id] = val;
+            }
+        }
+        for (auto i = 0ul; i < input_ids_l.size(); ++i) {
+            // Generate expected values with expected ordering
+            for (auto v : this->inputs_l[i]) {
+                this->expected_values.push_back(v.second);
+                this->input_values_l.push_back(v.second);
+            }
+            for (auto v : this->inputs_r[i]) {
+                this->expected_values.push_back(v.second);
+                this->input_values_r.push_back(v.second);
+            }
+        }
+    }
+};
+
+TEST_F(FilledLandmarkContainer, emplace) {
+    // Check emplacement that occured in the test fixture constructor
+    auto i = 0ul;
+    for (auto a = this->m.begin(); a != this->m.end(); ++a) {
+        ASSERT_PRED2(VectorsNear, this->expected_values[i++], a->value);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, eraseByKey) {
+    ASSERT_EQ(this->expected_values.size(), this->m.size());
+
+    // Erase non-existent key
+    auto res = this->m.erase(this->t_start, CameraSensors::Left, 99);
+    EXPECT_EQ(0ul, res);
+    EXPECT_EQ(this->expected_values.size(), this->m.size());
+
+    // Erase existent key
+    res = this->m.erase(this->t_start, CameraSensors::Right, 1);
+    EXPECT_EQ(1ul, res);
+    EXPECT_EQ(this->expected_values.size() - 1, m.size());
+}
+
+TEST_F(FilledLandmarkContainer, eraseByPosition) {
+    // Erase existent position
+    auto a = this->m.begin();
+    auto res = this->m.erase(a);
+    EXPECT_EQ(++a, res);
+    EXPECT_EQ(this->expected_values.size() - 1, m.size());
+    EXPECT_PRED2(VectorsNear, this->expected_values[1], this->m.begin()->value);
+
+    // Erase last position
+    auto end = this->m.end();
+    res = this->m.erase(--end);
+    EXPECT_EQ(this->m.end(), res);
+    EXPECT_EQ(this->expected_values.size() - 2, m.size());
+    auto last = std::prev(this->m.end());
+    EXPECT_PRED2(VectorsNear,
+                 this->expected_values[this->expected_values.size() - 2],
+                 last->value);
+}
+
+TEST_F(FilledLandmarkContainer, eraseByRange) {
+    auto a = std::next(this->m.begin(), 1);
+    auto b = std::next(this->m.begin(), 3);
+
+    auto res = this->m.erase(a, b);
+    EXPECT_EQ(b, res);
+    EXPECT_EQ(this->expected_values.size() - 2, m.size());
+    EXPECT_PRED2(VectorsNear, this->expected_values[0], this->m.begin()->value);
+    EXPECT_PRED2(VectorsNear, this->expected_values[3], b->value);
+}
+
+TEST_F(FilledLandmarkContainer, iterators) {
+    // Since I'm just wrapping internal iterators, just do a simple sanity check
+    EXPECT_EQ(this->expected_values.size(),
+              std::distance(this->m.begin(), this->m.end()));
+    EXPECT_EQ(this->expected_values.size(),
+              std::distance(this->m.cbegin(), this->m.cend()));
+
+    // Note the container supports range-based for loops
+    auto i = 0ul;
+    for (auto &v : this->m) {
+        EXPECT_PRED2(VectorsNear, this->expected_values[i++], v.value);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, constructFromRange) {
+    auto first = this->m.begin();
+    auto last = this->m.end();
+    auto m2 = TestContainer(first, last);
+
+    // Check that the copy has the same content as the original
+    ASSERT_EQ(this->m.size(), m2.size());
+    auto it = m2.begin();
+    while (it != m2.end()) {
+        EXPECT_EQ(first++->value, it++->value);
+    }
+
+    // Check that the copy is independent of the original
+    this->m.erase(this->t_start, CameraSensors::Right, 1);
+    EXPECT_LT(this->m.size(), m2.size());
+}
+
+TEST_F(FilledLandmarkContainer, insertRange) {
+    auto a = std::next(this->m.begin(), 1);
+    auto b = std::next(this->m.begin(), 3);
+
+    auto m2 = TestContainer{};
+    m2.insert(a, b);
+    EXPECT_EQ(2ul, m2.size());
+
+    auto it = m2.begin();
+    EXPECT_PRED2(VectorsNear, this->expected_values[1], it->value);
+    EXPECT_PRED2(VectorsNear, this->expected_values[2], (++it)->value);
+
+    m2.insert(a, ++b);
+    EXPECT_EQ(3ul, m2.size());
+}
+
+TEST_F(FilledLandmarkContainer, getTimeWindowEmpty) {
+    // Check case of window with no measurements
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t - seconds(2), t - seconds(1));
+    EXPECT_EQ(res.first, res.second);
+}
+
+TEST_F(FilledLandmarkContainer, getTimeWindowBackwards) {
+    // Check case of backwards window
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t + seconds(10), t);
+    EXPECT_EQ(res.first, res.second);
+}
+
+TEST_F(FilledLandmarkContainer, getTimeWindowAll) {
+    // Check case of window containing all measurements
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t, t + seconds(99));
+    EXPECT_EQ(this->m.size(), std::distance(res.first, res.second));
+
+    for (auto i = 0ul; res.first != res.second; ++i, ++res.first) {
+        EXPECT_PRED2(VectorsNear, this->expected_values[i], res.first->value);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getTimeWindowSome) {
+    // Check case of window containing some measurements
+    // The expected values here are manually picked by inspecting the fixture
+
+    const auto t = this->t_start;
+    auto res = this->m.getTimeWindow(t + seconds(1), t + seconds(2));
+    EXPECT_EQ(6, std::distance(res.first, res.second));
+
+    auto exp_first = this->expected_values.begin() + 2;
+    auto exp_last = exp_first + 6;
+    const auto expected = std::vector<Vec2>(exp_first, exp_last);
+
+    for (int i = 0; res.first != res.second; ++i, ++res.first) {
+        EXPECT_PRED2(VectorsNear, expected[i], res.first->value);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getLandmarkIDs) {
+    auto ids = this->m.getLandmarkIDs();
+
+    // These expected values were counted manually from above
+    auto expected_ids = std::vector<LandmarkId>{1, 2, 3, 4, 5, 6, 25};
+    ASSERT_EQ(expected_ids.size(), ids.size());
+    for (auto i = 0ul; i < expected_ids.size(); ++i) {
+        EXPECT_EQ(expected_ids[i], ids[i]);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getAllFromSensor) {
+    // Check case of empty result
+    const auto t = this->t_start;
+    auto res = this->m.getAllFromSensor(CameraSensors::Top);
+    EXPECT_EQ(res.first, res.second);
+
+    // Check case of filled result
+    res = this->m.getAllFromSensor(CameraSensors::Right);
+    EXPECT_EQ(this->input_values_r.size(),
+              std::distance(res.first, res.second));
+
+    for (auto i = 0; res.first != res.second; ++res.first, ++i) {
+        EXPECT_PRED2(VectorsNear, this->input_values_r[i], res.first->value);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowEmpty) {
+    // Check case of window with no measurements
+    const auto t = this->t_start;
+    auto ids = this->m.getLandmarkIDsInWindow(t - seconds(2), t - seconds(1));
+    EXPECT_TRUE(ids.empty());
+}
+
+TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowBackwards) {
+    const auto t = this->t_start;
+    // Check case of backwards window
+    auto ids = this->m.getLandmarkIDsInWindow(t + seconds(10), t);
+    EXPECT_TRUE(ids.empty());
+}
+TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowAll) {
+    // Check case of window containing all measurements
+    const auto t = this->t_start;
+    // These expected values were chosen manually from the fixture
+    auto ids = this->m.getLandmarkIDsInWindow(t, t + seconds(10));
+
+    auto expected_ids = std::vector<LandmarkId>{1, 2, 3, 4, 5, 6, 25};
+    EXPECT_EQ(expected_ids.size(), ids.size());
+    for (auto i = 0ul; i < ids.size(); ++i) {
+        EXPECT_EQ(expected_ids[i], ids[i]);
+    }
+}
+TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowSome) {
+    // Check case of window containing some measurements
+    const auto t = this->t_start;
+    auto ids = this->m.getLandmarkIDsInWindow(t + seconds(5), t + seconds(6));
+    const auto expected2 = std::vector<LandmarkId>{1, 3, 4};
+    EXPECT_EQ(expected2.size(), ids.size());
+    for (auto i = 0ul; i < ids.size(); ++i) {
+        EXPECT_EQ(expected2[i], ids[i]);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getTrackInWindowEmpty) {
+    // Check case of window with no measurements
+    const auto t = this->t_start;
+    auto track = this->m.getTrackInWindow(
+      CameraSensors::Right, 4, t - seconds(2), t - seconds(1));
+    EXPECT_TRUE(track.empty());
+}
+
+TEST_F(FilledLandmarkContainer, getTrackInWindowBackwards) {
+    const auto t = this->t_start;
+    // Check case of backwards window
+    auto track =
+      this->m.getTrackInWindow(CameraSensors::Right, 4, t + seconds(10), t);
+    EXPECT_TRUE(track.empty());
+}
+
+TEST_F(FilledLandmarkContainer, getTrackInWindowAll) {
+    // Check case of window containing all measurements
+    const auto t = this->t_start;
+    auto track =
+      this->m.getTrackInWindow(CameraSensors::Right, 4, t, t + seconds(10));
+    // These expected values were chosen manually from the fixture
+    auto expected_times =
+      std::vector<TimeType>{t + seconds(2), t + seconds(3), t + seconds(6)};
+
+    ASSERT_EQ(expected_times.size(), track.size());
+    for (auto i = 0ul; i < track.size(); ++i) {
+        EXPECT_EQ(expected_times[i], track[i].time_point);
+        EXPECT_EQ(CameraSensors::Right, track[i].sensor_id);
+        EXPECT_EQ(4ul, track[i].landmark_id);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getTrackInWindowSome) {
+    // Check case of window containing all measurements
+    const auto t = this->t_start;
+    auto track = this->m.getTrackInWindow(
+      CameraSensors::Right, 4, t + seconds(3), t + seconds(4));
+
+    // These expected values were chosen manually from the fixture
+    auto expected_times = std::vector<TimeType>{t + seconds(3)};
+
+    ASSERT_EQ(expected_times.size(), track.size());
+    for (auto i = 0ul; i < track.size(); ++i) {
+        EXPECT_EQ(expected_times[i], track[i].time_point);
+        EXPECT_EQ(CameraSensors::Right, track[i].sensor_id);
+        EXPECT_EQ(4ul, track[i].landmark_id);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getTrack) {
+    const auto t = this->t_start;
+    auto track = this->m.getTrack(CameraSensors::Right, 4);
+
+    // This expected results are the same as getTrackInWindowAll
+    // These expected values were chosen manually from the fixture
+    auto expected_times =
+      std::vector<TimeType>{t + seconds(2), t + seconds(3), t + seconds(6)};
+
+    ASSERT_EQ(expected_times.size(), track.size());
+    for (auto i = 0ul; i < track.size(); ++i) {
+        EXPECT_EQ(expected_times[i], track[i].time_point);
+        EXPECT_EQ(CameraSensors::Right, track[i].sensor_id);
+        EXPECT_EQ(4ul, track[i].landmark_id);
+    }
+}
+
+TEST_F(FilledLandmarkContainer, getTrackEmpty) {
+    // Check cases of a query with no measurements
+    const auto t = this->t_start;
+    auto track = this->m.getTrack(CameraSensors::Top, 4);
+    EXPECT_TRUE(track.empty());
+
+    track = this->m.getTrack(CameraSensors::Left, 999);
+    EXPECT_TRUE(track.empty());
+}
+
+}  // namespace wave

--- a/wave_containers/tests/containers/landmark_measurement_test.cpp
+++ b/wave_containers/tests/containers/landmark_measurement_test.cpp
@@ -241,11 +241,11 @@ TEST_F(FilledLandmarkContainer, eraseByRange) {
 }
 
 TEST_F(FilledLandmarkContainer, iterators) {
+    auto expected_size = static_cast<signed>(this->expected_values.size());
+
     // Since I'm just wrapping internal iterators, just do a simple sanity check
-    EXPECT_EQ(this->expected_values.size(),
-              std::distance(this->m.begin(), this->m.end()));
-    EXPECT_EQ(this->expected_values.size(),
-              std::distance(this->m.cbegin(), this->m.cend()));
+    EXPECT_EQ(expected_size, std::distance(this->m.begin(), this->m.end()));
+    EXPECT_EQ(expected_size, std::distance(this->m.cbegin(), this->m.cend()));
 
     // Note the container supports range-based for loops
     auto i = 0ul;
@@ -305,7 +305,8 @@ TEST_F(FilledLandmarkContainer, getTimeWindowAll) {
     // Check case of window containing all measurements
     const auto t = this->t_start;
     auto res = this->m.getTimeWindow(t, t + seconds(99));
-    EXPECT_EQ(this->m.size(), std::distance(res.first, res.second));
+    EXPECT_EQ(static_cast<signed>(this->m.size()),
+              std::distance(res.first, res.second));
 
     for (auto i = 0ul; res.first != res.second; ++i, ++res.first) {
         EXPECT_PRED2(VectorsNear, this->expected_values[i], res.first->value);
@@ -342,13 +343,12 @@ TEST_F(FilledLandmarkContainer, getLandmarkIDs) {
 
 TEST_F(FilledLandmarkContainer, getAllFromSensor) {
     // Check case of empty result
-    const auto t = this->t_start;
     auto res = this->m.getAllFromSensor(CameraSensors::Top);
     EXPECT_EQ(res.first, res.second);
 
     // Check case of filled result
     res = this->m.getAllFromSensor(CameraSensors::Right);
-    EXPECT_EQ(this->input_values_r.size(),
+    EXPECT_EQ(static_cast<signed>(this->input_values_r.size()),
               std::distance(res.first, res.second));
 
     for (auto i = 0; res.first != res.second; ++res.first, ++i) {
@@ -461,7 +461,6 @@ TEST_F(FilledLandmarkContainer, getTrack) {
 
 TEST_F(FilledLandmarkContainer, getTrackEmpty) {
     // Check cases of a query with no measurements
-    const auto t = this->t_start;
     auto track = this->m.getTrack(CameraSensors::Top, 4);
     EXPECT_TRUE(track.empty());
 

--- a/wave_containers/tests/containers/measurement_test.cpp
+++ b/wave_containers/tests/containers/measurement_test.cpp
@@ -43,8 +43,6 @@ TEST(Utils_measurement, emplace) {
     auto res2 = m.emplace(now, SomeSensors::S1, 2.5);
     EXPECT_FALSE(res2.second);
     EXPECT_EQ(res.first, res2.first);
-
-    std::vector<double> v;
 }
 
 TEST(Utils_measurement, capacity) {

--- a/wave_utils/include/wave/wave_test.hpp
+++ b/wave_utils/include/wave/wave_test.hpp
@@ -7,5 +7,18 @@
 #define WAVE_TEST_HPP
 
 #include <gtest/gtest.h>
+#include "wave/utils/math.hpp"
+
+namespace wave {
+
+/** Predicate to check is vectors are approximately equal.
+ * Use with EXPECT_PRED2 */
+inline bool VectorsNear(const VecX &v1, const VecX &v2) {
+    // The absolute comparison of isMuchSmallerThan works better for us than
+    // relative comparison of isApprox
+    return v1.isApprox(v2);
+}
+
+}  // namespace wave
 
 #endif  // WAVE_TEST_HPP


### PR DESCRIPTION
Resolves #41

The LandmarkMeasurement is a Measurement with an additional landmark_id
property, and a value type of Eigen::Vector2d representing pixel coordinates.

The LandmarkMeasurementContainer stores these measurements and offers these new
operations (on top of the MeasurementContainer methods):

- getLandmarkIDs()
- getLandmarkIDsInWindow()
- getTrack()
- getTrackInWindow()

Interpolation is not supported for landmark measurements.

I realize a lot of code is duplicated from the MeasurementContainer class
template. I started on an implementation that would reuse code, but because the
underlying types are different, code reuse requires an even more template-heavy
approach. I guessed reviewers would not be fans. I suggest pushing this
duplicated code and refactoring later.