### PR TITLE
Travis build status image: use master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libwave [![Build Status](https://travis-ci.org/wavelab/libwave.png)][1]
+# libwave [![Build Status](https://travis-ci.org/wavelab/libwave.png?branch=master)][1]
 
 This library contains reusable code for:
 


### PR DESCRIPTION
Fix #86 

Without a branch specified, it appears the Travis build status image (see https://docs.travis-ci.com/user/status-images/) shows the status of the latest build regardless of branch. Need to specify "branch=master" to show only status of the default branch.

Testing:
Currently the README on this branch shows "build passing" while master shows "build failing".