### PR TITLE
Temporarily disable travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ language:
 
 cache:
     ccache: true
-    directories:
-        - /usr/local/src
 
 install:
     - sudo bash scripts/install/install_deps.bash


### PR DESCRIPTION
See #76

This cache step is failing after three minutes, so it is actually adding time to each build.

Remove until a better solution is implemented.