### PR TITLE
Add "this" keyword to checkConfiguration function

### DIFF
--- a/wave_vision/config/fast.yaml
+++ b/wave_vision/config/fast.yaml
@@ -1,16 +1,17 @@
-fast:
-  # Threshold on difference between intensity of the central pixel, and pixels
-  # in a circle (Bresenham radius 3) around this pixel.
-  # 10 (default), must be greater than zero.
-  threshold: 10
+# Configuration Parameters for FAST Feature Detector
 
-  # Removes keypoints in adjacent locations
-  # true (default), or false
-  nonmax_supression: true
+# Threshold on difference between intensity of the central pixel, and pixels
+# in a circle (Bresenham radius 3) around this pixel.
+# 10 (default), must be greater than zero.
+threshold: 10
 
-  # Neighbourhood, as defined in the paper by Rosten. May only be the following:
-  # 0 = TYPE_5_8
-  # 1 = TYPE_7_12
-  # 2 = TYPE_9_16 (default)
-  type: 2
+# Removes keypoints in adjacent locations
+# true (default), or false
+nonmax_suppression: true
+
+# Neighbourhood, as defined in the paper by Rosten. May only be the following:
+# 0 = TYPE_5_8
+# 1 = TYPE_7_12
+# 2 = TYPE_9_16 (default)
+type: 2
   

--- a/wave_vision/include/wave/vision/fast_detector.hpp
+++ b/wave_vision/include/wave/vision/fast_detector.hpp
@@ -1,6 +1,6 @@
 /**
  * @file
- * Fast Feature Detector implementation, derived from Feature Detector base
+ * FAST Feature Detector implementation, derived from Feature Detector base
  * class.
  * @ingroup vision
  */
@@ -12,7 +12,7 @@
 #include <vector>
 
 /** Libwave Headers */
-#include "wave/vision/feature_detector.hpp"
+#include "wave/vision/detector/feature_detector.hpp"
 
 /** The wave namespace */
 namespace wave {
@@ -44,6 +44,12 @@ struct FASTParams {
      *  0 = TYPE_5_8
      *  1 = TYPE_7_12
      *  2 = TYPE_9_16 (default)
+     *
+     *  The neighbourhood refers to the pixel circumference and number of
+     *  pixels that must be brighter or darker than the center pixel for the
+     *  algorithm to deem the point as a corner. For example, TYPE_9_16
+     *  requires 9 consecutive pixels out of a 16 pixel circumference circle to
+     *  be brighter or darker than the center pixel.
      */
     int type;
 };

--- a/wave_vision/include/wave/vision/fast_detector.hpp
+++ b/wave_vision/include/wave/vision/fast_detector.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 /** Libwave Headers */
-#include "wave/vision/detector/feature_detector.hpp"
+#include "wave/vision/feature_detector.hpp"
 
 /** The wave namespace */
 namespace wave {

--- a/wave_vision/include/wave/vision/feature_detector.hpp
+++ b/wave_vision/include/wave/vision/feature_detector.hpp
@@ -22,15 +22,6 @@ namespace wave {
  *  @{ */
 
 /**
- * Custom exception class for a failed attempt at loading a configuration
- */
-class ConfigurationLoadingException : public std::exception {
-    const char *what() const throw() {
-        return "Failed to Load Detector Configuration";
-    }
-};
-
-/**
  * Representation of a generic feature detector.
  *
  * Internally, this class, and all derived classes are wrapping various
@@ -62,7 +53,7 @@ class FeatureDetector {
     virtual std::vector<cv::KeyPoint> detectFeatures(const cv::Mat &image) = 0;
 
  protected:
-    // The image currently being detected.
+    /** The image currently being detected. */
     cv::Mat image;
 
     /** Function to set image within the member variables.

--- a/wave_vision/src/fast_detector.cpp
+++ b/wave_vision/src/fast_detector.cpp
@@ -1,5 +1,5 @@
 // Libwave Headers
-#include "wave/vision/detector/fast_detector.hpp"
+#include "wave/vision/fast_detector.hpp"
 
 namespace wave {
 

--- a/wave_vision/src/fast_detector.cpp
+++ b/wave_vision/src/fast_detector.cpp
@@ -35,9 +35,9 @@ FASTDetector::FASTDetector(const std::string &config_path) {
 
     // Add parameters to parser, to be loaded. If path cannot be found, throw an
     // exception.
-    parser.addParam("fast.threshold", &config.threshold);
-    parser.addParam("fast.nonmax_suppression", &config.nonmax_suppression);
-    parser.addParam("fast.type", &config.type);
+    parser.addParam("threshold", &config.threshold);
+    parser.addParam("nonmax_suppression", &config.nonmax_suppression);
+    parser.addParam("type", &config.type);
 
     if (parser.load(config_path) != 0) {
         throw std::invalid_argument(

--- a/wave_vision/src/fast_detector.cpp
+++ b/wave_vision/src/fast_detector.cpp
@@ -18,7 +18,7 @@ FASTDetector::FASTDetector() {
 // Constructor using FASTParams struct
 FASTDetector::FASTDetector(const FASTParams &config) {
     // Ensure parameters are valid
-    checkConfiguration(config);
+    this->checkConfiguration(config);
 
     // Create FastFeatureDetector with these parameters
     this->fast_detector = cv::FastFeatureDetector::create(
@@ -44,7 +44,7 @@ FASTDetector::FASTDetector(const std::string &config_path) {
     }
 
     // Verify configuration values
-    checkConfiguration(config);
+    this->checkConfiguration(config);
 
     // Create FastFeatureDetector with these parameters
     this->fast_detector = cv::FastFeatureDetector::create(
@@ -64,7 +64,7 @@ void FASTDetector::checkConfiguration(const FASTParams &check_config) {
 
 void FASTDetector::configure(const FASTParams &new_config) {
     // Confirm configuration parameters are valid
-    checkConfiguration(new_config);
+    this->checkConfiguration(new_config);
 
     // Set configuration values in detector.
     this->fast_detector->setThreshold(new_config.threshold);

--- a/wave_vision/src/fast_detector.cpp
+++ b/wave_vision/src/fast_detector.cpp
@@ -40,7 +40,8 @@ FASTDetector::FASTDetector(const std::string &config_path) {
     parser.addParam("fast.type", &config.type);
 
     if (parser.load(config_path) != 0) {
-        throw std::invalid_argument("Failed to Load Detector Configuration");
+        throw std::invalid_argument(
+          "Failed to Load FASTDetector Configuration");
     }
 
     // Verify configuration values

--- a/wave_vision/src/fast_detector.cpp
+++ b/wave_vision/src/fast_detector.cpp
@@ -1,5 +1,5 @@
 // Libwave Headers
-#include "wave/vision/fast_detector.hpp"
+#include "wave/vision/detector/fast_detector.hpp"
 
 namespace wave {
 
@@ -40,7 +40,7 @@ FASTDetector::FASTDetector(const std::string &config_path) {
     parser.addParam("fast.type", &config.type);
 
     if (parser.load(config_path) != 0) {
-        throw ConfigurationLoadingException{};
+        throw std::invalid_argument("Failed to Load Detector Configuration");
     }
 
     // Verify configuration values

--- a/wave_vision/tests/config/fast.yaml
+++ b/wave_vision/tests/config/fast.yaml
@@ -1,15 +1,16 @@
-fast:
-  # Threshold on difference between intensity of the central pixel, and pixels
-  # of a circle around this pixel
-  # 10 (default)
-  threshold: 10
+# Configuration Parameters for FAST Feature Detector
 
-  # Removes keypoints in adjacent locations
-  # true (default), or false
-  nonmax_suppression: true
+# Threshold on difference between intensity of the central pixel, and pixels
+# of a circle around this pixel
+# 10 (default)
+threshold: 10
 
-  # Neighbourhood, as defined in the paper by Rosten.
-  # 0 = TYPE_5_8
-  # 1 = TYPE_7_12
-  # 2 = TYPE_9_16 (default)
-  type: 2
+# Removes keypoints in adjacent locations
+# true (default), or false
+nonmax_suppression: true
+
+# Neighbourhood, as defined in the paper by Rosten.
+# 0 = TYPE_5_8
+# 1 = TYPE_7_12
+# 2 = TYPE_9_16 (default)
+type: 2

--- a/wave_vision/tests/fast_tests.cpp
+++ b/wave_vision/tests/fast_tests.cpp
@@ -36,8 +36,7 @@ TEST(FASTTests, GoodInitialization) {
 TEST(FASTTests, BadInitialization) {
     const std::string bad_path = "bad_path";
 
-    ASSERT_THROW(FASTDetector detector(bad_path),
-                 ConfigurationLoadingException);
+    ASSERT_THROW(FASTDetector detector(bad_path), std::invalid_argument);
 }
 
 // Checks that invalid threshold value throws the proper exception

--- a/wave_vision/tests/fast_tests.cpp
+++ b/wave_vision/tests/fast_tests.cpp
@@ -4,8 +4,8 @@
 
 namespace wave {
 
-const std::string TEST_CONFIG = "tests/config/fast.yaml";
-const std::string TEST_IMAGE = "tests/data/lenna.png";
+const auto TEST_CONFIG = "tests/config/fast.yaml";
+const auto TEST_IMAGE = "tests/data/lenna.png";
 
 // Test fixture to load same image data
 class FASTTest : public testing::Test {


### PR DESCRIPTION
Fixes #114. Forgot to add the this-> keyword to the checkConfiguration member function. Also removed the custom configuration, using std::invalid_argument now.

Also improved the comments within fast_detector.