### PR TITLE
Install opencv3 from ppa

### DIFF
--- a/scripts/install/opencv3_install.bash
+++ b/scripts/install/opencv3_install.bash
@@ -1,77 +1,8 @@
 #!/bin/bash
 set -e  # exit on first error
-OPENCV_URL=https://github.com/opencv/opencv/archive/3.2.0.zip
 
+echo "Installing OpenCV3 from a Personal Package Archive..."
 
-install_dependencies() {
-    apt-get -y install -qq \
-        libopencv-dev \
-        build-essential \
-        cmake \
-        git \
-        libgtk2.0-dev \
-        pkg-config \
-        python-dev \
-        python-numpy \
-        libdc1394-22 \
-        libdc1394-22-dev \
-        libjpeg-dev \
-        libpng12-dev \
-        libtiff*-dev \
-        libjasper-dev \
-        libavcodec-dev \
-        libavformat-dev \
-        libswscale-dev \
-        libxine2-dev \
-        libgstreamer0.10-dev \
-        libgstreamer-plugins-base0.10-dev \
-        libv4l-dev \
-        libtbb-dev \
-        libqt4-dev \
-        libfaac-dev \
-        libmp3lame-dev \
-        libopencore-amrnb-dev \
-        libopencore-amrwb-dev \
-        libtheora-dev \
-        libvorbis-dev \
-        libxvidcore-dev \
-        x264 \
-        v4l-utils \
-        unzip
-}
-
-download_opencv() {
-    mkdir -p /usr/local/src/opencv
-    cd /usr/local/src/opencv
-    if [ ! -d opencv-3.2.0 ]; then
-        wget $OPENCV_URL -O opencv3.2.0.zip
-        unzip -qq opencv3.2.0.zip
-        rm opencv3.2.0.zip
-    fi
-    cd -
-}
-
-install_opencv() {
-    # compile and install opencv
-    cd /usr/local/src/opencv/
-    cd opencv-3.2.0
-    mkdir -p build
-    cd build
-    cmake \
-        -D CMAKE_BUILD_TYPE=RELEASE \
-        -D CMAKE_INSTALL_PREFIX=/usr/local \
-        -D WITH_TBB=ON \
-        -D WITH_V4L=ON \
-        -D WITH_QT=ON \
-        -D WITH_OPENGL=ON ..
-    make -j$(nproc)
-
-    # THIS WILL CAUSE PROBLEMS WITH BUILDS THAT DEPEND ON OPENCV 2
-    # THE REASON IS /usr/local/lib has precedence over /usr/lib
-    make install
-}
-
-# MAIN
-install_dependencies
-download_opencv
-install_opencv
+sudo add-apt-repository -y ppa:lkoppel/opencv
+sudo apt-get -q update
+sudo apt-get install -y -q libopencv-dev


### PR DESCRIPTION
Resolves #106 

I created a debian package for opencv3.2.0 with the [configuration here](https://github.com/leokoppel/opencv/tree/3.2.0-trusty/debian), based on the [Debian opencv 3.1.0 experimental package](https://packages.debian.org/source/experimental/opencv). It is currently built on [my ppa](https://launchpad.net/~lkoppel/+archive/ubuntu/opencv) for both trusty and xenial.

This package includes most opencv modules (e.g. no gstreamer or matlab support) and almost all opencv_contrib modules (no dnn or tracking). Maybe should cut down what is installed on travis to speed up builds?

#### Pre-Merge Checklist:
- [x] ~Code is documented in doxygen format~
- [x] ~Code has automated tests~
- [x] Zero compiler warnings
- [x] ~Formatted with `clang-format`~

Testing: lightly tested opencv examples, libwave unit tests, on trusty and xenial VMs.