### PR TITLE
Install ceres from ppa

### DIFF
--- a/scripts/install/ceres_install.bash
+++ b/scripts/install/ceres_install.bash
@@ -1,58 +1,15 @@
 #!/bin/bash
 set -e  # exit on first error
+
 UBUNTU_VERSION=`lsb_release --release | cut -f2`
-SRC_PREFIX_PATH="/usr/local/src/"
-CERES_VERSION=1.12.0
 
-
-install_dependencies() {
-    apt-get update -qq
-    apt-get install -qq -y cmake \
-                           libgoogle-glog-dev \
-                           libatlas-base-dev \
-                           libeigen3-dev \
-                           libsuitesparse-dev
-}
-
-install_suitesparse_fix() {
-    add-apt-repository ppa:bzindovic/suitesparse-bugfix-1319687 -y
-    apt-get update -qq
-    apt-get install -qq libsuitesparse-dev
-}
-
-install_ceres_solver() {
-    mkdir -p $SRC_PREFIX_PATH
-    cd $SRC_PREFIX_PATH
-
-    if [ ! -d ceres-solver ]; then
-        # clone ceres-solver if directory does not already exist
-       git clone https://github.com/ceres-solver/ceres-solver.git
-    else
-        # otherwise, fetch to ensure we have the newest tags
-       git -C ceres-solver fetch
-    fi
-
-    # go into ceres-solver repo and prepare for build
-    cd ceres-solver
-    git checkout tags/${CERES_VERSION}
-    mkdir -p build
-    cd build
-    cmake ..
-
-    # compile and install
-    make -j$(nproc)
-    # Test, but skip the slowest tests
-    make test ARGS="-E 'bundle_adjustment|covariance|rotation'"
-    make install
-}
-
-# MAIN
-if [ $UBUNTU_VERSION == "16.04" ]; then
-    install_dependencies
-    install_ceres_solver
-
-elif [ $UBUNTU_VERSION == "14.04" ]; then
-    install_dependencies
-    install_suitesparse_fix
-    install_ceres_solver
+if [[ "$UBUNTU_VERSION" == "14.04" || "$UBUNTU_VERSION" == "16.04" ]]; then
+    # Ceres 1.12 is not available in official repos until zesty
+    # For these earlier versions, use a ppa
+    sudo add-apt-repository -y ppa:lkoppel/ceres
 fi
+
+sudo apt-get -q update
+
+# Install the package and all dependencies
+sudo apt-get install -y -q libceres-dev


### PR DESCRIPTION
Resolves #132

I created [a ppa](https://launchpad.net/~lkoppel/+archive/ubuntu/ceres) hosting backports of https://launchpad.net/ubuntu/+source/ceres-solver for trusty and xenial. It is Ceres 1.12.0.

Testing: ceres tests are run during the build on launchpad. I ran libwave tests on a xenial VM. Travis build time is decreased about 8 minutes.