### PR TITLE
Don't download pcl docs on travis

### DIFF
--- a/scripts/install/pcl_install.bash
+++ b/scripts/install/pcl_install.bash
@@ -38,5 +38,5 @@ elif [ $UBUNTU_VERSION == "14.04" ]; then
     install_dependencies_14
     sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/pcl
     sudo apt-get -y update
-    sudo apt-get -y install -qq libpcl-all
+    sudo apt-get -y install -qq libpcl-1.7-all-dev
 fi


### PR DESCRIPTION
Trusty is mainly used on travis CI. The libpcl-all package contains 70 MB of docs. Travis doesn't need that.

Speeds up travis build.
