### PR TITLE
Switch to PCL 1.8

### DIFF
--- a/scripts/install/pcl_install.bash
+++ b/scripts/install/pcl_install.bash
@@ -1,42 +1,14 @@
 #!/bin/bash
 set -e  # exit on first error
 
-install_dependencies_14() {
-    sudo apt-get -y install -qq \
-    libboost-all-dev \
-    libflann-dev \
-    libeigen3-dev \
-    libusb-1.0-0-dev \
-	libvtk6 \
-	libvtk6-java \
-	python-vtk6 \
-	tcl-vtk6 \
-	libqt5opengl5
-}
-
-install_dependencies_16() {
-    sudo apt-get -y install -qq \
-    libboost-all-dev \
-    libeigen3-dev \
-    libflann-dev \
-    libopenni-dev \
-    libpcl1.7 \
-    libqhull-dev \
-    libvtk6-dev \
-    libvtk6-qt-dev
-}
-
-echo "Installing PCL ..."
+echo "Installing PCL 1.8..."
 
 UBUNTU_VERSION=`lsb_release --release | cut -f2`
 
-if [ $UBUNTU_VERSION == "16.04" ]; then
-    install_dependencies_16
-    sudo apt-get -y install -qq libpcl-dev
-
-elif [ $UBUNTU_VERSION == "14.04" ]; then
-    install_dependencies_14
-    sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/pcl
-    sudo apt-get -y update
-    sudo apt-get -y install -qq libpcl-1.7-all-dev
+if [[ "$UBUNTU_VERSION" == "14.04" || "$UBUNTU_VERSION" == "16.04" ]]; then
+    # PCL 1.8 is not available from official repo in these versions
+    sudo add-apt-repository -y ppa:lkoppel/robotics
+    sudo apt update
 fi
+
+sudo apt-get install -qq libpcl-dev


### PR DESCRIPTION
I backported PCL 1.8 from https://packages.ubuntu.com/zesty/libpcl-dev to trusty and xenial, and added to [my ppa](https://launchpad.net/~lkoppel/+archive/ubuntu/robotics). I know some members of the team were trying to use 1.8.

Testing:
- PCL's unit tests run on launchpad when building for ppa.
- Ran libwave unit tests after clean install on trusty and xenial VMs.