### PR TITLE
Use container-based travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,30 @@
 dist: trusty
-sudo: required
+sudo: false
 
-language:
-    - c++
+language: cpp
 
 cache:
-    ccache: true
+  ccache: true
 
-before_install:
-    - bash scripts/ci/ci_check.bash
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:lkoppel/robotics'
+    packages:
+      - libboost-dev
+      - libyaml-cpp-dev
+      - libeigen3-dev
+      - libpcl-dev
+      - libopencv-dev
+      - libceres-dev
+      - libkindr-dev
+      - clang-format-3.8
 
-install:
-    - travis_wait 20 sudo bash scripts/install/install_deps.bash
+before_script:
+  - bash scripts/ci/ci_check.bash
 
 script:
-    - bash scripts/ci/ci_run.bash
+  - bash scripts/ci/ci_run.bash
 
 notifications:
-    email: false
+  email: false

--- a/scripts/ci/ci_check.bash
+++ b/scripts/ci/ci_check.bash
@@ -3,8 +3,7 @@ set -e  # exit on first error
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)" # This script's directory
 
 check_format() {
-    # Install and use clang-format-3.8, not the version preiinstalled on CI
-    sudo apt-get -qq install clang-format-3.8
+    # Use specifically clang-format-3.8 on CI
     export FORMAT_EXE=clang-format-3.8
 
     # Run clang-format on all files

--- a/scripts/ci/ci_run.bash
+++ b/scripts/ci/ci_run.bash
@@ -8,7 +8,9 @@ compile_libwave() {
     cd build
     cmake .. -DCMAKE_MODULE_PATH=$DIR/$CMAKE_CONFIG_DIR \
         -DCMAKE_CXX_FLAGS="-Werror -Wno-error=deprecated-declarations"
-    make -j$(nproc)
+    make -j2  # Travis gives two cores
+
+    # (don't rely on nproc: https://github.com/travis-ci/travis-ci/issues/6859)
 }
 
 test_libwave() {


### PR DESCRIPTION
The [container-based environment](https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta) has a [faster boot time](https://docs.travis-ci.com/user/ci-environment/). 

It has no sudo, but we don't need it. To install dependencies, use travis' "APT Addon":
    https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-with-the-APT-Addon

The downside is travis would no longer test the dependency install script itself. I think that's not a big loss especially as it uses a different Ubuntu version than most actual users.