### PR TITLE
Add camera models from kalibr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ ENDFOREACH()
 ADD_SUBDIRECTORY(deps/googletest)
 INCLUDE_DIRECTORIES(${gtest_SOURCE_DIR}/include/ ${gtest_SOURCE_DIR})
 
+# 3rd party modules
+ADD_SUBDIRECTORY(deps/aslam_cameras)
+
 # Define dependencies between modules
 # libwave_controls.a
 ADD_DEPENDENCIES(wave_controls wave_utils)

--- a/deps/aslam_cameras/CMakeLists.txt
+++ b/deps/aslam_cameras/CMakeLists.txt
@@ -1,0 +1,40 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.3)
+PROJECT(aslam_cameras)
+
+FIND_PACKAGE(Boost REQUIRED COMPONENTS system filesystem)
+FIND_PACKAGE(Eigen3 REQUIRED)
+FIND_PACKAGE(OpenCV REQUIRED)
+
+INCLUDE_DIRECTORIES(include
+    ${Boost_INCLUDE_DIR}
+    ${EIGEN3_INCLUDE_DIR}
+    ${OpenCV_INCLUDE_DIRS})
+
+#common commands for building c++ executables and libraries
+ADD_LIBRARY(${PROJECT_NAME}
+    STATIC
+    src/CameraGeometryBase.cpp
+    src/GlobalShutter.cpp
+    src/RollingShutter.cpp
+    src/NoMask.cpp
+    src/NoDistortion.cpp
+    src/RadialTangentialDistortion.cpp
+    src/EquidistantDistortion.cpp
+    src/FovDistortion.cpp
+    src/ImageMask.cpp)
+
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${Boost_LIBRARIES})
+
+# Avoid clash with tr1::tuple: https://code.google.com/p/googletest/source/browse/trunk/README?r=589#257
+ADD_DEFINITIONS(-DGTEST_USE_OWN_TR1_TUPLE=0)
+
+WAVE_ADD_TEST(${PROJECT_NAME}_tests
+    test/PinholeCameraGeometry.cpp
+    test/OmniCameraGeometry.cpp
+    test/RadialTangentialDistortion.cpp
+    test/EquidistantDistortion.cpp
+    test/FovDistortion.cpp)
+
+TARGET_LINK_LIBRARIES(${PROJECT_NAME}_tests
+    ${PROJECT_NAME}
+    ${Boost_LIBRARIES})

--- a/deps/aslam_cameras/LICENSE
+++ b/deps/aslam_cameras/LICENSE
@@ -1,0 +1,34 @@
+Copyright (c) 2014, Paul Furgale, Jérôme Maye and Jörn Rehder, Autonomous Systems Lab, 
+                    ETH Zurich, Switzerland
+Copyright (c) 2014, Thomas Schneider, Skybotix AG, Switzerland
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this 
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, 
+    this list of conditions and the following disclaimer in the documentation 
+    and/or other materials provided with the distribution.
+
+    All advertising materials mentioning features or use of this software must 
+    display the following acknowledgement: This product includes software developed 
+    by the Autonomous Systems Lab and Skybotix AG.
+
+    Neither the name of the Autonomous Systems Lab and Skybotix AG nor the names 
+    of its contributors may be used to endorse or promote products derived from 
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTONOMOUS SYSTEMS LAB AND SKYBOTIX AG ''AS IS'' 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL the AUTONOMOUS SYSTEMS LAB OR SKYBOTIX AG BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+

--- a/deps/aslam_cameras/include/aslam/cameras.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras.hpp
@@ -1,0 +1,105 @@
+#ifndef ASLAM_CAMERAS_HPP
+#define ASLAM_CAMERAS_HPP
+
+// The camera geometery mother class
+#include <aslam/cameras/CameraGeometry.hpp>
+
+// Projection models
+#include <aslam/cameras/PinholeProjection.hpp>
+#include <aslam/cameras/OmniProjection.hpp>
+#include <aslam/cameras/DepthProjection.hpp>
+
+// Distortion models
+#include <aslam/cameras/NoDistortion.hpp>
+#include <aslam/cameras/RadialTangentialDistortion.hpp>
+#include <aslam/cameras/EquidistantDistortion.hpp>
+#include <aslam/cameras/FovDistortion.hpp>
+
+// Masks
+#include <aslam/cameras/NoMask.hpp>
+#include <aslam/cameras/ImageMask.hpp>
+
+// Shutter models
+#include <aslam/cameras/RollingShutter.hpp>
+#include <aslam/cameras/GlobalShutter.hpp>
+
+namespace aslam {
+namespace cameras {
+
+typedef CameraGeometry<PinholeProjection<NoDistortion>, GlobalShutter, NoMask> PinholeCameraGeometry;
+typedef CameraGeometry<PinholeProjection<RadialTangentialDistortion>,
+    GlobalShutter, NoMask> DistortedPinholeCameraGeometry;
+typedef CameraGeometry<PinholeProjection<EquidistantDistortion>, GlobalShutter,
+    NoMask> EquidistantDistortedPinholeCameraGeometry;
+typedef CameraGeometry<PinholeProjection<FovDistortion>, GlobalShutter,
+    NoMask> FovDistortedPinholeCameraGeometry;
+
+typedef CameraGeometry<OmniProjection<NoDistortion>, GlobalShutter, NoMask> OmniCameraGeometry;
+typedef CameraGeometry<OmniProjection<RadialTangentialDistortion>,
+    GlobalShutter, NoMask> DistortedOmniCameraGeometry;
+typedef CameraGeometry<OmniProjection<EquidistantDistortion>, GlobalShutter,
+    NoMask> EquidistantDistortedOmniCameraGeometry;
+typedef CameraGeometry<OmniProjection<FovDistortion>, GlobalShutter,
+    NoMask> FovDistortedOmniCameraGeometry;
+
+typedef CameraGeometry<PinholeProjection<NoDistortion>, RollingShutter, NoMask> PinholeRsCameraGeometry;
+typedef CameraGeometry<PinholeProjection<RadialTangentialDistortion>,
+    RollingShutter, NoMask> DistortedPinholeRsCameraGeometry;
+typedef CameraGeometry<PinholeProjection<EquidistantDistortion>, RollingShutter,
+    NoMask> EquidistantDistortedPinholeRsCameraGeometry;
+typedef CameraGeometry<PinholeProjection<FovDistortion>, RollingShutter,
+    NoMask> FovDistortedPinholeRsCameraGeometry;
+
+typedef CameraGeometry<OmniProjection<NoDistortion>, RollingShutter, NoMask> OmniRsCameraGeometry;
+typedef CameraGeometry<OmniProjection<RadialTangentialDistortion>,
+    RollingShutter, NoMask> DistortedOmniRsCameraGeometry;
+typedef CameraGeometry<OmniProjection<EquidistantDistortion>, RollingShutter,
+    NoMask> EquidistantDistortedOmniRsCameraGeometry;
+typedef CameraGeometry<OmniProjection<FovDistortion>, RollingShutter,
+    NoMask> FovDistortedOmniRsCameraGeometry;
+
+typedef CameraGeometry<PinholeProjection<NoDistortion>, GlobalShutter, ImageMask> MaskedPinholeCameraGeometry;
+typedef CameraGeometry<PinholeProjection<RadialTangentialDistortion>,
+    GlobalShutter, ImageMask> MaskedDistortedPinholeCameraGeometry;
+typedef CameraGeometry<PinholeProjection<EquidistantDistortion>, GlobalShutter,
+    ImageMask> MaskedEquidistantDistortedPinholeCameraGeometry;
+typedef CameraGeometry<PinholeProjection<FovDistortion>, GlobalShutter,
+    ImageMask> MaskedFovDistortedPinholeCameraGeometry;
+
+typedef CameraGeometry<OmniProjection<NoDistortion>, GlobalShutter, ImageMask> MaskedOmniCameraGeometry;
+typedef CameraGeometry<OmniProjection<RadialTangentialDistortion>,
+    GlobalShutter, ImageMask> MaskedDistortedOmniCameraGeometry;
+typedef CameraGeometry<OmniProjection<EquidistantDistortion>, GlobalShutter,
+    ImageMask> MaskedEquidistantDistortedOmniCameraGeometry;
+typedef CameraGeometry<OmniProjection<FovDistortion>, GlobalShutter,
+    ImageMask> MaskedFovDistortedOmniCameraGeometry;
+
+typedef CameraGeometry<PinholeProjection<NoDistortion>, RollingShutter,
+    ImageMask> MaskedPinholeRsCameraGeometry;
+typedef CameraGeometry<PinholeProjection<RadialTangentialDistortion>,
+    RollingShutter, ImageMask> MaskedDistortedPinholeRsCameraGeometry;
+typedef CameraGeometry<PinholeProjection<EquidistantDistortion>, RollingShutter,
+    ImageMask> MaskedEquidistantDistortedPinholeRsCameraGeometry;
+typedef CameraGeometry<PinholeProjection<FovDistortion>, RollingShutter,
+    ImageMask> MaskedFovDistortedPinholeRsCameraGeometry;
+
+typedef CameraGeometry<OmniProjection<NoDistortion>, RollingShutter, ImageMask> MaskedOmniRsCameraGeometry;
+typedef CameraGeometry<OmniProjection<RadialTangentialDistortion>,
+    RollingShutter, ImageMask> MaskedDistortedOmniRsCameraGeometry;
+typedef CameraGeometry<OmniProjection<EquidistantDistortion>, RollingShutter,
+    ImageMask> MaskedEquidistantDistortedOmniRsCameraGeometry;
+typedef CameraGeometry<OmniProjection<FovDistortion>, RollingShutter,
+    ImageMask> MaskedFovDistortedOmniRsCameraGeometry;
+
+typedef CameraGeometry<DepthProjection<NoDistortion>, GlobalShutter, NoMask> DepthCameraGeometry;
+typedef CameraGeometry<DepthProjection<RadialTangentialDistortion>,
+    GlobalShutter, NoMask> DistortedDepthCameraGeometry;
+typedef CameraGeometry<DepthProjection<EquidistantDistortion>, GlobalShutter,
+    NoMask> EquidistantDistortedDepthCameraGeometry;
+typedef CameraGeometry<DepthProjection<FovDistortion>, GlobalShutter,
+    NoMask> FovDistortedDepthCameraGeometry;
+
+}  // namespace cameras
+}  // namespace aslam
+
+#endif /* ASLAM_CAMERAS_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/CameraGeometry.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/CameraGeometry.hpp
@@ -1,0 +1,342 @@
+#ifndef ASLAM_CAMERA_GEOMETRY_HPP
+#define ASLAM_CAMERA_GEOMETRY_HPP
+
+#include <aslam/cameras/CameraGeometryBase.hpp>
+#include "FiniteDifferences.hpp"
+
+
+namespace aslam {
+
+namespace cameras {
+
+/**
+ * \class CameraGeometry
+ * 
+ * A camera geometry class based on three configurable policies:
+ * 1. a lens type that determines the geometry of the camera
+ * 2. a shutter type that determines the timing of each pixel.
+ * 3. a mask type.
+ *
+ */
+template<typename PROJECTION_T, typename SHUTTER_T, typename MASK_T>
+class CameraGeometry : public CameraGeometryBase {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  typedef PROJECTION_T projection_t;
+  // Not all projections will have a distortion...is this necessary? Maybe.
+  //typedef typename projection_t::distortion_t distortion_t;
+  typedef typename projection_t::keypoint_t keypoint_t;
+  typedef SHUTTER_T shutter_t;
+  typedef MASK_T mask_t;
+
+  enum {
+    KeypointDimension = projection_t::KeypointDimension
+  };
+
+  typedef Eigen::Matrix<double, KeypointDimension, 4> jacobian_homogeneous_t;
+  typedef Eigen::Matrix<double, KeypointDimension, 3> jacobian_t;
+  typedef Eigen::Matrix<double, 3, KeypointDimension> inverse_jacobian_t;
+  typedef Eigen::Matrix<double, 4, KeypointDimension> inverse_jacobian_homogeneous_t;
+  typedef Eigen::Matrix<double, KeypointDimension, KeypointDimension> covariance_t;
+
+  /// \brief default constructor
+  CameraGeometry();
+
+  /// \brief Construct from projection
+  CameraGeometry(const projection_t & projection);
+
+  /// \brief Construct from projection and shutter
+  CameraGeometry(const projection_t & projection, const shutter_t & shutter);
+
+  /// \brief Construct from projection, shutter, and mask
+  CameraGeometry(const projection_t & projection, const shutter_t & shutter,
+                 const mask_t & mask);
+
+  /// \brief simple destructor
+  virtual ~CameraGeometry();
+
+  //////////////////////////////////////////////////////////////
+  // PROJECTION FUNCTIONS
+  //////////////////////////////////////////////////////////////
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool euclideanToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool euclideanToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                           const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                           const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool euclideanToKeypointFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+      const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool homogeneousToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool homogeneousToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                             const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                             const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool homogeneousToKeypointFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+      const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                           const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToEuclideanFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_K> & keypoint,
+      const Eigen::MatrixBase<DERIVED_P> & outPoint,
+      const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToHomogeneous(
+      const Eigen::MatrixBase<DERIVED_K> & keypoint,
+      const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToHomogeneous(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                             const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                             const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToHomogeneousFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_K> & keypoint,
+      const Eigen::MatrixBase<DERIVED_P> & outPoint,
+      const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void euclideanToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void euclideanToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void euclideanToKeypointIntrinsicsJacobianFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void euclideanToKeypointDistortionJacobianFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void homogeneousToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void homogeneousToKeypointIntrinsicsJacobianFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JS>
+  void homogeneousToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JS> & outJs) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void homogeneousToKeypointDistortionJacobianFiniteDifference(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  //////////////////////////////////////////////////////////////
+  // SHUTTER SUPPORT
+  //////////////////////////////////////////////////////////////
+
+  // The amount of time elapsed between the start of the image and the
+  // keypoint. For a global shutter camera, this can return Duration(0).
+  template<typename DERIVED_K>
+  Duration temporalOffset(const Eigen::MatrixBase<DERIVED_K> & keypoint) const;
+
+  virtual Duration temporalOffset(const Eigen::VectorXd & keypoint) const;
+
+  //////////////////////////////////////////////////////////////
+  // VALIDITY TESTING
+  //////////////////////////////////////////////////////////////
+
+  template<typename DERIVED_K>
+  bool isValid(const Eigen::MatrixBase<DERIVED_K> & keypoint) const;
+
+  template<typename DERIVED_P>
+  bool isEuclideanVisible(const Eigen::MatrixBase<DERIVED_P> & p) const;
+
+  template<typename DERIVED_P>
+  bool isHomogeneousVisible(const Eigen::MatrixBase<DERIVED_P> & ph) const;
+
+  //////////////////////////////////////////////////////////////
+  // SUPERCLASS SUPPORT
+  //////////////////////////////////////////////////////////////
+  virtual bool vsEuclideanToKeypoint(const Eigen::Vector3d & p,
+                                     Eigen::VectorXd & outKeypoint) const;
+  virtual bool vsEuclideanToKeypoint(const Eigen::Vector3d & p,
+                                     Eigen::VectorXd & outKeypoint,
+                                     Eigen::MatrixXd & outJacobian) const;
+
+  virtual bool vsHomogeneousToKeypoint(const Eigen::Vector4d & ph,
+                                       Eigen::VectorXd & outKeypoint) const;
+
+  virtual bool vsHomogeneousToKeypoint(const Eigen::Vector4d & ph,
+                                       Eigen::VectorXd & outKeypoint,
+                                       Eigen::MatrixXd & outJacobian) const;
+
+  virtual bool vsKeypointToEuclidean(const Eigen::VectorXd & keypoint,
+                                     Eigen::Vector3d & outPoint) const;
+
+  virtual bool vsKeypointToEuclidean(const Eigen::VectorXd & keypoint,
+                                     Eigen::VectorXd & outPoint,
+                                     Eigen::MatrixXd & outJacobian) const;
+
+  virtual bool vsKeypointToHomogeneous(Eigen::VectorXd const & keypoint,
+                                       Eigen::VectorXd & outPoint) const;
+
+  virtual bool vsKeypointToHomogeneous(Eigen::VectorXd const & keypoint,
+                                       Eigen::VectorXd & outPoint,
+                                       Eigen::MatrixXd & outJacobian) const;
+
+  virtual bool vsIsValid(const Eigen::VectorXd & keypoint) const;
+
+  virtual bool vsIsEuclideanVisible(const Eigen::Vector3d & p) const;
+
+  virtual bool vsIsHomogeneousVisible(const Eigen::Vector4d & ph) const;
+
+  // The amount of time elapsed between the start of the image and the
+  // keypoint. For a global shutter camera, this can return Duration(0).
+  virtual Duration vsTemporalOffset(const Eigen::VectorXd & keypoint) const;
+
+  /// \brief the length of a keypoint
+  virtual size_t keypointDimension() const;
+
+  /// \brief is this an invertible camera model
+  virtual bool isProjectionInvertible() const;
+
+    ////////////////////////////////////////////////////////////////
+  // OPTIMIZATION SUPPORT
+  ////////////////////////////////////////////////////////////////
+  /// \brief the minimal dimensions of the projection parameters
+  virtual int minimalDimensionsProjection() const;
+
+  /// \brief the minimal dimensions of the distortion parameters
+  virtual int minimalDimensionsDistortion() const;
+
+  /// \brief the minimal dimensions of the shutter parameters
+  virtual int minimalDimensionsShutter() const;
+
+  // aslam::backend compatibility
+
+  /// \brief update the intrinsics
+  virtual void update(const double * v, bool projection, bool distortion,
+                      bool shutter);
+
+  /// \brief Get the total number of dimensions of the intrinsic parameters
+  virtual int minimalDimensions(bool projection, bool distortion,
+                                bool shutter) const;
+
+  /// \brief get the intrinsic parameters.
+  virtual void getParameters(Eigen::MatrixXd & P, bool projection,
+                             bool distortion, bool shutter) const;
+
+  /// \brief set the intrinsic parameters.
+  virtual void setParameters(const Eigen::MatrixXd & P, bool projection,
+                             bool distortion, bool shutter);
+
+  /// \brief return the Jacobian of the projection with respect to the intrinsics.
+  virtual void euclideanToKeypointIntrinsicsJacobian(
+      const Eigen::Vector3d & p, Eigen::MatrixXd & outJi,
+      bool estimateProjection, bool estimateDistortion,
+      bool estimateShutter) const;
+
+  /// \brief return the Jacobian of the projection with respect to the intrinsics.
+  virtual void homogeneousToKeypointIntrinsicsJacobian(
+      const Eigen::Vector4d & p, Eigen::MatrixXd & outJi,
+      bool estimateProjection, bool estimateDistortion,
+      bool estimateShutter) const;
+
+  /// \brief return the temporal offset with respect to the intrinsics.
+  virtual void temporalOffsetIntrinsicsJacobian(
+      const Eigen::VectorXd & keypoint, Eigen::MatrixXd & outJi,
+      bool estimateProjection, bool estimateDistortion,
+      bool estimateShutter) const;
+
+  //////////////////////////////////////////////////////////////
+  // UNIT TEST SUPPORT
+  //////////////////////////////////////////////////////////////
+  // \brief creates a random valid keypoint.
+  virtual Eigen::VectorXd createRandomKeypoint() const;
+
+  // \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+  virtual Eigen::Vector3d createRandomVisiblePoint(double depth = -1.0) const;
+
+  projection_t & projection() {
+    return _projection;
+  }
+  const projection_t & projection() const {
+    return _projection;
+  }
+
+  shutter_t & shutter() {
+    return _shutter;
+  }
+  const shutter_t & shutter() const {
+    return _shutter;
+  }
+
+  void setMask(const mask_t & mask) {
+    _mask = mask;
+  }
+  mask_t & mask() {
+    return _mask;
+  }
+  const mask_t & mask() const {
+    return _mask;
+  }
+
+  virtual bool hasMask() const
+  {
+	  return _mask.isSet();
+  }
+
+  virtual void print(std::ostream & out);
+
+  static CameraGeometry<PROJECTION_T, SHUTTER_T, MASK_T> getTestGeometry();
+
+  /// \todo redo this. Somehow Stefan's stuff needs it.
+  virtual int width() const {
+    return _projection.ru();
+  }
+  virtual int height() const {
+    return _projection.rv();
+  }
+ private:
+  projection_t _projection;
+  shutter_t _shutter;
+  mask_t _mask;
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/CameraGeometry.hpp"
+
+#endif /* ASLAM_CAMERA_GEOMETRY_BASE_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/CameraGeometryBase.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/CameraGeometryBase.hpp
@@ -1,0 +1,149 @@
+#ifndef ASLAM_CAMERA_GEOMETRY_BASE_HPP
+#define ASLAM_CAMERA_GEOMETRY_BASE_HPP
+
+#include <boost/shared_ptr.hpp>
+#include <Eigen/Core>
+
+#include "aslam/cameras/Duration.hpp"
+
+namespace sm {
+namespace kinematics {
+class Transformation;
+}  // namespace kinematics
+}  // namespace sm
+
+namespace aslam {
+// Forward declaration
+class FrameBase;
+namespace cameras {
+
+// The base class for camera geometry...this will help exporting things to python or supporting
+// runtime polymorphism but it will be a bit slower than pure templated code.
+class CameraGeometryBase {
+ public:
+  typedef boost::shared_ptr<CameraGeometryBase> Ptr;
+  typedef boost::shared_ptr<const CameraGeometryBase> ConstPtr;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  CameraGeometryBase();
+  virtual ~CameraGeometryBase();
+
+  virtual size_t keypointDimension() const = 0;
+
+  // The functions below take variable sized matrices and hence they are prefixed by "vs" to avoid confusion with
+  // the fixed-size matrix versions available in derived classes. The default implementation of these "vs" functions
+  // will be inefficient as it will call the fixed-size derived functions and copy the data into the variable size matrices.
+  // Still, this base class is useful as it allows us to maintain a heterogeneous list of camera geometries and simplify the
+  // python interface.
+  virtual bool vsEuclideanToKeypoint(const Eigen::Vector3d & p,
+                                     Eigen::VectorXd & outKeypoint) const = 0;
+  virtual bool vsEuclideanToKeypoint(const Eigen::Vector3d & p,
+                                     Eigen::VectorXd & outKeypoint,
+                                     Eigen::MatrixXd & outJacobian) const = 0;
+
+  virtual bool vsHomogeneousToKeypoint(const Eigen::Vector4d & ph,
+                                       Eigen::VectorXd & outKeypoint) const = 0;
+
+  virtual bool vsHomogeneousToKeypoint(const Eigen::Vector4d & ph,
+                                       Eigen::VectorXd & outKeypoint,
+                                       Eigen::MatrixXd & outJacobian) const = 0;
+
+  // If the camera model is invertible, these functions produce 3d
+  // points.  otherwise they produce points where the length has no
+  // meaning. In that case the points are not necessarily on the
+  // unit sphere in R^3 (that might be expensive to compute).
+  virtual bool vsKeypointToEuclidean(const Eigen::VectorXd & keypoint,
+                                     Eigen::Vector3d & outPoint) const = 0;
+
+  virtual bool vsKeypointToEuclidean(const Eigen::VectorXd & keypoint,
+                                     Eigen::VectorXd & outPoint,
+                                     Eigen::MatrixXd &outJacobian) const = 0;
+
+  virtual bool vsKeypointToHomogeneous(Eigen::VectorXd const & keypoint,
+                                       Eigen::VectorXd & outPoint) const = 0;
+
+  virtual bool vsKeypointToHomogeneous(Eigen::VectorXd const & keypoint,
+                                       Eigen::VectorXd & outPoint,
+                                       Eigen::MatrixXd & outJacobian) const = 0;
+
+  // The amount of time elapsed between the start of the image and the
+  // keypoint. For a global shutter camera, this can return Duration(0).
+  virtual Duration vsTemporalOffset(const Eigen::VectorXd & keypoint) const = 0;
+
+  // These functions are needed for unit testing.
+  virtual Eigen::VectorXd createRandomKeypoint() const = 0;
+  virtual Eigen::Vector3d createRandomVisiblePoint(double depth = -1) const = 0;
+
+  virtual bool vsIsValid(const Eigen::VectorXd & keypoint) const = 0;
+  virtual bool vsIsEuclideanVisible(const Eigen::Vector3d & p) const = 0;
+  virtual bool vsIsHomogeneousVisible(const Eigen::Vector4d & ph) const = 0;
+  virtual bool isProjectionInvertible() const = 0;
+
+    /// \brief The width of the underlying image
+  virtual int width() const = 0;
+
+  /// \brief The height of the underlying image
+  virtual int height() const = 0;
+
+  // The amount of time elapsed between the start of the image and the
+  // keypoint. For a global shutter camera, this can return Duration(0).
+  virtual Duration temporalOffset(const Eigen::VectorXd & keypoint) const = 0;
+
+  /// \brief print the internal parameters. This is just for debugging.
+  virtual void print(std::ostream & out) = 0;
+
+  // aslam::backend compatibility
+
+  /// \brief the minimal dimensions of the projection parameters
+  virtual int minimalDimensionsProjection() const = 0;
+
+  /// \brief the minimal dimensions of the distortion parameters
+  virtual int minimalDimensionsDistortion() const = 0;
+
+  /// \brief the minimal dimensions of the shutter parameters
+  virtual int minimalDimensionsShutter() const = 0;
+
+  // aslam::backend compatibility
+
+  /// \brief update the intrinsics
+  virtual void update(const double * v, bool projection, bool distortion,
+                      bool shutter) = 0;
+
+  /// \brief Get the total number of dimensions of the intrinsic parameters
+  virtual int minimalDimensions(bool projection, bool distortion,
+                                bool shutter) const = 0;
+
+  /// \brief get the intrinsic parameters.
+  virtual void getParameters(Eigen::MatrixXd & P, bool projection,
+                             bool distortion, bool shutter) const = 0;
+
+  /// \brief set the intrinsic parameters.
+  virtual void setParameters(const Eigen::MatrixXd & P, bool projection,
+                             bool distortion, bool shutter) = 0;
+
+  /// \brief return the Jacobian of the projection with respect to the intrinsics.
+  virtual void euclideanToKeypointIntrinsicsJacobian(
+      const Eigen::Vector3d & p, Eigen::MatrixXd & outJi,
+      bool estimateProjection, bool estimateDistortion,
+      bool estimateShutter) const = 0;
+
+  /// \brief return the Jacobian of the projection with respect to the intrinsics.
+  virtual void homogeneousToKeypointIntrinsicsJacobian(
+      const Eigen::Vector4d & p, Eigen::MatrixXd & outJi,
+      bool estimateProjection, bool estimateDistortion,
+      bool estimateShutter) const = 0;
+
+  /// \brief return the temporal offset with respect to the intrinsics.
+  virtual void temporalOffsetIntrinsicsJacobian(
+      const Eigen::VectorXd & keypoint, Eigen::MatrixXd & outJi,
+      bool estimateProjection, bool estimateDistortion,
+      bool estimateShutter) const = 0;
+
+  virtual bool hasMask() const;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#endif /* ASLAM_CAMERA_GEOMETRY_BASE_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/DepthProjection.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/DepthProjection.hpp
@@ -1,0 +1,208 @@
+#ifndef ASLAM_CAMERAS_DEPTH_PROJECTION_HPP
+#define ASLAM_CAMERAS_DEPTH_PROJECTION_HPP
+
+#include "StaticAssert.hpp"
+
+namespace aslam {
+namespace cameras {
+
+template<typename DISTORTION_T>
+class DepthProjection {
+ public:
+
+  enum {
+    KeypointDimension = 3
+  };
+
+  enum {
+    IntrinsicsDimension = 4
+  };
+  enum {
+    DesignVariableDimension = IntrinsicsDimension
+  };
+
+  typedef DISTORTION_T distortion_t;
+  typedef Eigen::Matrix<double, KeypointDimension, 1> keypoint_t;
+  typedef Eigen::Matrix<double, KeypointDimension, IntrinsicsDimension> jacobian_intrinsics_t;
+
+  /// \brief Default constructor
+  DepthProjection();
+
+  DepthProjection(distortion_t distortion);
+
+  DepthProjection(double focalLengthU, double focalLengthV, double imageCenterU,
+                  double imageCenterV, int resolutionU, int resolutionV,
+                  distortion_t distortion);
+
+  DepthProjection(double focalLengthU, double focalLengthV, double imageCenterU,
+                  double imageCenterV, int resolutionU, int resolutionV);
+
+  /// \brief destructor.
+  virtual ~DepthProjection();
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool euclideanToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool euclideanToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                           const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                           const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool homogeneousToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool homogeneousToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                             const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                             const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                           const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToHomogeneous(
+      const Eigen::MatrixBase<DERIVED_K> & keypoint,
+      const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToHomogeneous(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                             const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                             const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void euclideanToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void euclideanToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void homogeneousToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void homogeneousToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_K>
+  bool isValid(const Eigen::MatrixBase<DERIVED_K> & keypoint) const;
+
+  template<typename DERIVED_P>
+  bool isEuclideanVisible(const Eigen::MatrixBase<DERIVED_P> & p) const;
+
+  template<typename DERIVED_P>
+  bool isHomogeneousVisible(const Eigen::MatrixBase<DERIVED_P> & ph) const;
+
+  // aslam::backend compatibility
+  void update(const double * v);
+  int minimalDimensions() const;
+  void getParameters(Eigen::MatrixXd & P) const;
+  void setParameters(const Eigen::MatrixXd & P);
+  Eigen::Vector2i parameterSize() const;
+
+  // \brief creates a random valid keypoint.
+  virtual Eigen::VectorXd createRandomKeypoint() const;
+
+  // \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+  virtual Eigen::Vector3d createRandomVisiblePoint(double depth = -1.0) const;
+
+  bool isProjectionInvertible() const {
+    return false;
+  }
+
+  distortion_t & distortion() {
+    return _distortion;
+  }
+  ;
+  const distortion_t & distortion() const {
+    return _distortion;
+  }
+  ;
+
+  double focalLengthCol() const {
+    return _fu;
+  }
+  double focalLengthRow() const {
+    return _fv;
+  }
+  double opticalCenterCol() const {
+    return _cu;
+  }
+  double opticalCenterRow() const {
+    return _cv;
+  }
+
+  /// \brief The horizontal focal length in pixels.
+  double fu() const {
+    return _fu;
+  }
+  /// \brief The vertical focal length in pixels.
+  double fv() const {
+    return _fv;
+  }
+  /// \brief The horizontal image center in pixels.
+  double cu() const {
+    return _cu;
+  }
+  /// \brief The vertical image center in pixels.
+  double cv() const {
+    return _cv;
+  }
+  /// \brief The horizontal resolution in pixels.
+  int ru() const {
+    return _ru;
+  }
+  /// \brief The vertical resolution in pixels.
+  int rv() const {
+    return _rv;
+  }
+
+  /// \todo Fill in
+  static DepthProjection<DISTORTION_T> getTestProjection() {
+    return DepthProjection<DISTORTION_T>();
+  }
+
+ private:
+  /// \brief The horizontal focal length in pixels.
+  double _fu;
+  /// \brief The vertical focal length in pixels.
+  double _fv;
+  /// \brief The horizontal image center in pixels.
+  double _cu;
+  /// \brief The vertical image center in pixels.
+  double _cv;
+  /// \brief The horizontal resolution in pixels.
+  int _ru;
+  /// \brief The vertical resolution in pixels.
+  int _rv;
+
+  /// \brief A computed value for speeding up computation.
+  double _recip_fu;
+  double _recip_fv;
+  double _fu_over_fv;
+
+  distortion_t _distortion;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/DepthProjection.hpp"
+
+#endif /* ASLAM_CAMERAS_DEPTH_PROJECTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/Duration.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/Duration.hpp
@@ -1,0 +1,17 @@
+#ifndef ASLAM_CAMERA_DURATION_HPP
+#define ASLAM_CAMERA_DURATION_HPP
+
+/* aslam_cameras used a custom "Duration" class (for durations related to
+ * rolling shutters). This file contains definitions to convert that to
+ * std::chrono::duration.
+ */
+
+#include <chrono>
+
+namespace aslam {
+    // A duration storing seconds as a double
+    using Duration = std::chrono::duration<double>;
+
+}  // namespace aslam
+
+#endif  // ASLAM_CAMERA_DURATION_HPP

--- a/deps/aslam_cameras/include/aslam/cameras/EquidistantDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/EquidistantDistortion.hpp
@@ -1,0 +1,161 @@
+#ifndef ASLAM_CAMERAS_EQUI_DISTORTION_HPP
+#define ASLAM_CAMERAS_EQUI_DISTORTION_HPP
+
+#include <Eigen/Dense>
+#include "StaticAssert.hpp"
+
+namespace aslam {
+namespace cameras {
+
+/**
+ * \class EquidistantDistortion
+ * \brief An implementation of the equidistant distortion model for pinhole cameras.
+ *        
+ * See "A Generic Camera Model and Calibration Method for Conventional, Wide-Angle, and Fish-Eye Lenses" by Juho Kannala and Sami S. Brandt for further information
+ *
+ *
+ * The usual model of a pinhole camera follows these steps:
+ *   - Transformation: Transform the point into a coordinate frame associated with the camera
+ *   - Normalization:  Project the point onto the normalized image plane: \f$\mathbf y := \left[ x/z,y/z\right] \f$
+ *   - Distortion:     apply a nonlinear transformation to \f$y\f$ to account for distortions caused by the optics
+ *   - Projection:     Project the point into the image using a standard \f$3 \time 3\f$ projection matrix
+ *
+ * This class represents a standard implementation of the distortion block. The function "distort" applies this nonlinear transformation.
+ * The function "undistort" applies the inverse transformation. Note that the inverse transformation in this case is not avaialable in 
+ * closed form and so it is computed iteratively.
+ * 
+ */
+class EquidistantDistortion {
+ public:
+
+  enum {
+    IntrinsicsDimension = 4
+  };
+  enum {
+    DesignVariableDimension = IntrinsicsDimension
+  };
+
+  /// \brief The default constructor sets all values to zero. 
+  EquidistantDistortion();
+
+  /// \brief A constructor that initializes all values.
+  EquidistantDistortion(double k1, double k2, double k3, double k4);
+
+  virtual ~EquidistantDistortion();
+
+  /** 
+   * \brief Apply distortion to a point in the normalized image plane
+   * 
+   * @param y The point in the normalized image plane. After the function, this point is distorted.
+   */
+  template<typename DERIVED_Y>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y) const;
+
+  /** 
+   * 
+   * \brief Apply distortion to a point in the normalized image plane
+   * 
+   * @param y The point in the normalized image plane. After the function, this point is distorted.
+   * @param outJy The Jacobian of the distortion function with respect to small changes in the input point.
+   */
+  template<typename DERIVED_Y, typename DERIVED_JY>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y,
+               const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  /** 
+   * \brief Apply undistortion to recover a point in the normalized image plane.
+   * 
+   * @param y The distorted point. After the function, this point is in the normalized image plane.
+   */
+  template<typename DERIVED>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y) const;
+
+  /** 
+   * \brief Apply undistortion to recover a point in the normalized image plane.
+   * 
+   * @param y The distorted point. After the function, this point is in the normalized image plane.
+   * @param outJy The Jacobian of the undistortion function with respect to small changes in the input point.
+   */
+  template<typename DERIVED, typename DERIVED_JY>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y,
+                 const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  /** 
+   * \brief Apply distortion to the point and provide the Jacobian of the distortion with respect to small changes in the distortion parameters
+   * 
+   * @param imageY the point in the normalized image plane.
+   * @param outJd  the Jacobian of the distortion with respect to small changes in the distortion parameters.
+   */
+  template<typename DERIVED_Y, typename DERIVED_JD>
+  void distortParameterJacobian(
+      const Eigen::MatrixBase<DERIVED_Y> & imageY,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. This implements an update of the distortion parameter.
+   * 
+   * @param v A double array representing the update vector.
+   */
+  void update(const double * v);
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param v The number of parameters expected by the update equation. This should also define the number of columns in the matrix returned by distortParameterJacobian.
+   */
+  int minimalDimensions() const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param P This matrix is resized and filled with parameters representing the full state of the distortion. 
+   */
+  void getParameters(Eigen::MatrixXd & P) const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param P The full state of the distortion class is set from the matrix of parameters.
+   */
+  void setParameters(const Eigen::MatrixXd & P);
+
+  Eigen::Vector2i parameterSize() const;
+
+  /// \brief the first radial distortion parameter
+  double k1() {
+    return _k1;
+  }
+  /// \brief the second radial distortion parameter
+  double k2() {
+    return _k2;
+  }
+  /// \brief the first tangential distortion parameter
+  double k3() {
+    return _k3;
+  }
+  /// \brief the second tangential distortion parameter
+  double k4() {
+    return _k4;
+  }
+
+  static EquidistantDistortion getTestDistortion();
+
+  void clear();
+
+  /// \brief the first distortion parameter
+  double _k1;
+  /// \brief the second distortion parameter
+  double _k2;
+  /// \brief the third distortion parameter
+  double _k3;
+  /// \brief the forth distortion parameter
+  double _k4;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/EquidistantDistortion.hpp"
+
+#endif /* ASLAM_CAMERAS_EQUI_DISTORTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/FiniteDifferences.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/FiniteDifferences.hpp
@@ -1,0 +1,111 @@
+#ifndef ASLAM_CAMERAS_FINITE_DIFFERENCES_HPP
+#define ASLAM_CAMERAS_FINITE_DIFFERENCES_HPP
+
+#define ASLAM_CAMERAS_ESTIMATE_JACOBIAN(classPointer, functionName, x0, step, outJ) \
+  {																		\
+																		\
+	Eigen::VectorXd fx0;												\
+	classPointer->functionName(x0,fx0);									\
+	outJ.resize(fx0.size(), x0.size());									\
+	Eigen::VectorXd fxp, fxm;											\
+	Eigen::VectorXd x = x0;												\
+	for(unsigned c = 0; c < x0.size(); c++)								\
+	  {																	\
+		x(c) += step;													\
+		classPointer->functionName(x,fxp);								\
+																		\
+		x(c) -= 2.0*step;												\
+		classPointer->functionName(x,fxm);								\
+																		\
+		x(c) += step;													\
+		outJ.col(c) = (fxp - fxm)/(step*2.0);							\
+																		\
+	  }																	\
+																		\
+  }																		\
+	  
+
+#define ASLAM_CAMERAS_ESTIMATE_INTRINSIC_JACOBIAN(functionName, projectionClass, updateClass, x0, step, outJ) \
+  {																		\
+																		\
+		Eigen::VectorXd fx0;											\
+		projectionClass.functionName(x0,fx0);							\
+		Eigen::VectorXd fxa, fxb, fxc, fxd;								\
+		Eigen::MatrixXd I, IO;											\
+		updateClass.getParameters(I);									\
+		IO = I;															\
+																		\
+		outJ.resize(fx0.size(), I.size());								\
+		for(unsigned c = 0; c < I.size(); c++)							\
+		{																\
+			I(c,0) += 2.0 * step;					 					\
+			updateClass.setParameters( I );								\
+			projectionClass.functionName(x0,fxa);						\
+																		\
+			I(c,0) -= step;											    \
+			updateClass.setParameters(I);								\
+			projectionClass.functionName(x0,fxb);						\
+																		\
+			I(c,0) -= 2.0 * step;										\
+			updateClass.setParameters(I);								\
+			projectionClass.functionName(x0,fxc);						\
+																		\
+			I(c,0) -= step;												\
+			updateClass.setParameters(I);								\
+			projectionClass.functionName(x0,fxd);						\
+																		\
+			updateClass.setParameters(IO);								\
+			fx0 = ((8.0*fxb) + fxd - fxa - (8.0*fxc))/(step*12.0);		\
+																		\
+			for(int r = 0; r < outJ.rows(); ++r)						\
+			  outJ(r,c) = fx0(r);										\
+		}																\
+																		\
+  }																		\
+
+#define ASLAM_CAMERAS_ESTIMATE_DISTORTION_JACOBIAN(functionName, distortionClass, x0, step, outJ) \
+  {																		\
+																		\
+	    Eigen::VectorXd fx0 = x0;										\
+		Eigen::VectorXd fxa = x0, fxb = x0, fxc = x0, fxd = x0;			\
+		distortionClass.functionName(fx0);								\
+		Eigen::MatrixXd I, IO;											\
+		distortionClass.getParameters(I);								\
+		IO = I;															\
+																		\
+																		\
+        outJ.resize(fx0.size(), I.size());								\
+		for(int c = I.size() - 1; c >= 0; --c)							\
+		  {																\
+			fxa = x0;													\
+			I(c,0) += 2.0 * step;					 					\
+			distortionClass.setParameters( I );							\
+			distortionClass.functionName(fxa);							\
+																		\
+			fxb = x0;													\
+			I(c,0) -= step;											    \
+			distortionClass.setParameters(I);							\
+			distortionClass.functionName(fxb);							\
+																		\
+			fxc = x0;													\
+			I(c,0) -= 2.0 * step;										\
+			distortionClass.setParameters(I);							\
+			distortionClass.functionName(fxc);							\
+																		\
+			fxd = x0;													\
+			I(c,0) -= step;												\
+			distortionClass.setParameters(I);							\
+			distortionClass.functionName(fxd);							\
+																		\
+																		\
+			distortionClass.setParameters(IO);							\
+			fx0 = ( (8.0*fxb) + fxd - fxa - (8.0*fxc))/(step*12.0);		\
+																		\
+			for(int r = 0; r < outJ.rows(); ++r)						\
+			  outJ(r,c) = fx0(r);										\
+		}																\
+																		\
+  }																		\
+
+
+#endif /* ASLAM_CAMERAS_FINITE_DIFFERENCES_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/FovDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/FovDistortion.hpp
@@ -1,0 +1,135 @@
+#ifndef ASLAM_CAMERAS_FOV_DISTORTION_HPP
+#define ASLAM_CAMERAS_FOV_DISTORTION_HPP
+
+#include <Eigen/Dense>
+#include "StaticAssert.hpp"
+
+namespace aslam {
+namespace cameras {
+
+/**
+ * \class FovDistortion
+ * \brief An implementation of the fov distortion model for pinhole cameras.
+ */
+class FovDistortion {
+ public:
+
+  enum {
+    IntrinsicsDimension = 1
+  };
+  enum {
+    DesignVariableDimension = IntrinsicsDimension
+  };
+
+  /// \brief The default constructor sets all values to zero. 
+  FovDistortion();
+
+  /// \brief A constructor that initializes all values.
+  FovDistortion(double w);
+
+  virtual ~FovDistortion();
+
+  /** 
+   * \brief Apply distortion to a point in the normalized image plane
+   * 
+   * @param y The point in the normalized image plane. After the function, this point is distorted.
+   */
+  template<typename DERIVED_Y>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y) const;
+
+  /** 
+   * 
+   * \brief Apply distortion to a point in the normalized image plane
+   * 
+   * @param y The point in the normalized image plane. After the function, this point is distorted.
+   * @param outJy The Jacobian of the distortion function with respect to small changes in the input point.
+   */
+  template<typename DERIVED_Y, typename DERIVED_JY>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y,
+               const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  /** 
+   * \brief Apply undistortion to recover a point in the normalized image plane.
+   * 
+   * @param y The distorted point. After the function, this point is in the normalized image plane.
+   */
+  template<typename DERIVED>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y) const;
+
+  /** 
+   * \brief Apply undistortion to recover a point in the normalized image plane.
+   * 
+   * @param y The distorted point. After the function, this point is in the normalized image plane.
+   * @param outJy The Jacobian of the undistortion function with respect to small changes in the input point.
+   */
+  template<typename DERIVED, typename DERIVED_JY>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y,
+                 const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  /** 
+   * \brief Apply distortion to the point and provide the Jacobian of the distortion with respect to small changes in the distortion parameters
+   * 
+   * @param imageY the point in the normalized image plane.
+   * @param outJd  the Jacobian of the distortion with respect to small changes in the distortion parameters.
+   */
+  template<typename DERIVED_Y, typename DERIVED_JD>
+  void distortParameterJacobian(
+      const Eigen::MatrixBase<DERIVED_Y> & imageY,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. This implements an update of the distortion parameter.
+   * 
+   * @param v A double array representing the update vector.
+   */
+  void update(const double * v);
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param v The number of parameters expected by the update equation. This should also define the number of columns in the matrix returned by distortParameterJacobian.
+   */
+  int minimalDimensions() const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param P This matrix is resized and filled with parameters representing the full state of the distortion. 
+   */
+  void getParameters(Eigen::MatrixXd & P) const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param P The full state of the distortion class is set from the matrix of parameters.
+   */
+  void setParameters(const Eigen::MatrixXd & P);
+
+  Eigen::Vector2i parameterSize() const;
+
+  double w() {
+    return _w;
+  }
+
+  /// Static function that checks whether the given intrinsic parameters are valid for this model.
+  bool areParametersValid(double w) {
+    return std::abs(w) < 1e-16 || (w >= kMinValidW && w <= kMaxValidW);
+  }
+
+  static FovDistortion getTestDistortion();
+
+  void clear();
+
+  /// \brief the disortion parameter
+  double _w;
+  static constexpr double kMaxValidAngle = (89.0 * M_PI / 180.0);
+  static constexpr double kMinValidW = 0.5;
+  static constexpr double kMaxValidW = 1.5;
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/FovDistortion.hpp"
+
+#endif /* ASLAM_CAMERAS_FOV_DISTORTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/GlobalShutter.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/GlobalShutter.hpp
@@ -1,0 +1,52 @@
+#ifndef ASLAM_GLOBAL_SHUTTER_HPP
+#define ASLAM_GLOBAL_SHUTTER_HPP
+
+#include <Eigen/Core>
+#include "Duration.hpp"
+
+namespace aslam {
+namespace cameras {
+
+class GlobalShutter {
+
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  enum {
+    DesignVariableDimension = 0
+  };
+
+  GlobalShutter();
+  ~GlobalShutter();
+
+  template<typename K>
+  Duration temporalOffset(const K & /* k */ ) const {
+    return Duration(0);
+  }
+
+  template<typename DERIVED_K, typename DERIVED_J>
+  void temporalOffsetIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_K> & /* k */,
+      const Eigen::MatrixBase<DERIVED_J> & outJ) const {
+    Eigen::MatrixBase<DERIVED_J> & J =
+        const_cast<Eigen::MatrixBase<DERIVED_J> &>(outJ);
+    J.resize(0, 0);
+
+  }
+
+  // aslam::backend compatibility
+  void update(const double * v);
+  int minimalDimensions() const;
+  void getParameters(Eigen::MatrixXd & P) const;
+  void setParameters(const Eigen::MatrixXd & P);
+  Eigen::Vector2i parameterSize() const;
+
+  static GlobalShutter getTestShutter() {
+    return GlobalShutter();
+  }
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#endif /* ASLAM_GLOBAL_SHUTTER_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/ImageMask.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/ImageMask.hpp
@@ -1,0 +1,47 @@
+#ifndef ASLAM_CAMERAS_IMAGE_MASK_HPP
+#define ASLAM_CAMERAS_IMAGE_MASK_HPP
+
+#include <Eigen/Core>
+#include <opencv2/core.hpp>
+
+namespace aslam {
+namespace cameras {
+
+class ImageMask {
+ public:
+  ImageMask();
+  ImageMask(const cv::Mat& mask, double scale = 1.0);
+  ~ImageMask();
+
+  void setMask(const cv::Mat& mask);
+  const cv::Mat & getMask() const;
+
+  void setScale(double scale);
+  double getScale() const;
+
+  // These guys mainly support the python interface
+  void setMaskFromMatrix(const Eigen::MatrixXi & mask);
+  Eigen::MatrixXi getMaskAsMatrix() const;
+
+  template<typename DERIVED>
+  bool isValid(const Eigen::MatrixBase<DERIVED> & k) const {
+    int k1 = k(1, 0) * _scale;
+    int k0 = k(0, 0) * _scale;
+    // \todo fix this when it is initialized properly
+    return !_mask.data || (_mask.at<unsigned char>(k1, k0) > 0);
+    //return true;
+  }
+
+  // is the mask set? (i.e. mask data != NULL)
+  bool isSet () const;
+
+ private:
+  cv::Mat _mask;
+  double _scale;
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+
+#endif /* ASLAM_CAMERAS_IMAGE_MASK_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/NoDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/NoDistortion.hpp
@@ -1,0 +1,65 @@
+#ifndef ASLAM_CAMERAS_NO_DISTORTION_HPP
+#define ASLAM_CAMERAS_NO_DISTORTION_HPP
+
+#include <Eigen/Core>
+#include "StaticAssert.hpp"
+
+namespace aslam {
+namespace cameras {
+
+class NoDistortion {
+ public:
+
+  enum {
+    DesignVariableDimension = 0
+  };
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  enum {
+    IntrinsicsDimension = -1  //!< The number of distortion coefficients
+  };
+
+  NoDistortion();
+  virtual ~NoDistortion();
+
+  template<typename DERIVED_Y>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y) const;
+
+  template<typename DERIVED_Y, typename DERIVED_JY>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y,
+               const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  template<typename DERIVED>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y) const;
+
+  template<typename DERIVED, typename DERIVED_JY>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y,
+                 const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  template<typename DERIVED_Y, typename DERIVED_JD>
+  void distortParameterJacobian(
+      const Eigen::MatrixBase<DERIVED_Y> & imageY,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  // aslam::backend compatibility
+  void update(const double * v);
+  int minimalDimensions() const;
+  void getParameters(Eigen::MatrixXd & P) const;
+  void setParameters(const Eigen::MatrixXd & P);
+  Eigen::Vector2i parameterSize() const;
+
+  static NoDistortion getTestDistortion() {
+    return NoDistortion();
+  }
+
+  void clear() {
+  }
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/NoDistortion.hpp"
+
+#endif /* ASLAM_CAMERAS_DISTORTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/NoMask.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/NoMask.hpp
@@ -1,0 +1,35 @@
+#ifndef ASLAM_CAMERAS_NO_MASK_HPP
+#define ASLAM_CAMERAS_NO_MASK_HPP
+
+
+namespace aslam {
+namespace cameras {
+
+class NoMask {
+ public:
+
+  enum {
+    DesignVariableDimension = 0
+  };
+
+  NoMask();
+  ~NoMask();
+
+  template<typename K>
+  bool isValid(const K & /* k */) const {
+    return true;
+  }
+
+  // is the mask set? (i.e. mask data != NULL)
+  bool isSet () const { return false; }
+
+  static NoMask getTestMask() {
+    return NoMask();
+  }
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#endif /* ASLAM_CAMERAS_NO_MASK_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/OmniProjection.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/OmniProjection.hpp
@@ -1,0 +1,249 @@
+#ifndef ASLAM_CAMERAS_OMNI_PROJECTION_HPP
+#define ASLAM_CAMERAS_OMNI_PROJECTION_HPP
+
+#include "StaticAssert.hpp"
+#include "FiniteDifferences.hpp"
+
+
+namespace aslam {
+namespace cameras {
+
+template<typename DISTORTION_T>
+class OmniProjection {
+ public:
+
+  enum {
+    KeypointDimension = 2
+  };
+  enum {
+    IntrinsicsDimension = 5
+  };
+  enum {
+    DesignVariableDimension = IntrinsicsDimension
+  };
+
+  typedef DISTORTION_T distortion_t;
+  typedef Eigen::Matrix<double, KeypointDimension, 1> keypoint_t;
+  typedef Eigen::Matrix<double, KeypointDimension, IntrinsicsDimension> jacobian_intrinsics_t;
+
+  /// \brief Default constructor
+  OmniProjection();
+
+  OmniProjection(double xi, double focalLengthU, double focalLengthV,
+                 double imageCenterU, double imageCenterV, int resolutionU,
+                 int resolutionV, distortion_t distortion);
+
+  OmniProjection(double xi, double focalLengthU, double focalLengthV,
+                 double imageCenterU, double imageCenterV, int resolutionU,
+                 int resolutionV);
+
+  /// \brief destructor.
+  virtual ~OmniProjection();
+
+  /// \brief resize the intrinsics based on a scaling of the image.
+  void resizeIntrinsics(double scale);
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool euclideanToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool euclideanToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                           const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                           const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool homogeneousToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool homogeneousToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                             const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                             const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                           const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToHomogeneous(
+      const Eigen::MatrixBase<DERIVED_K> & keypoint,
+      const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToHomogeneous(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                             const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                             const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void euclideanToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void euclideanToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void homogeneousToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void homogeneousToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_K>
+  bool isValid(const Eigen::MatrixBase<DERIVED_K> & keypoint) const;
+
+  template<typename DERIVED_K>
+  bool isLiftable(const Eigen::MatrixBase<DERIVED_K> & keypoint) const;
+
+  bool isUndistortedKeypointValid(const double rho2_d) const;
+
+  template<typename DERIVED_P>
+  bool isEuclideanVisible(const Eigen::MatrixBase<DERIVED_P> & p) const;
+
+  template<typename DERIVED_P>
+  bool isHomogeneousVisible(const Eigen::MatrixBase<DERIVED_P> & ph) const;
+
+    // aslam::backend compatibility
+  void update(const double * v);
+  int minimalDimensions() const;
+  void getParameters(Eigen::MatrixXd & P) const;
+  void setParameters(const Eigen::MatrixXd & P);
+  Eigen::Vector2i parameterSize() const;
+
+  /// \brief creates a random valid keypoint.
+  virtual Eigen::VectorXd createRandomKeypoint() const;
+
+  /// \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+  virtual Eigen::Vector3d createRandomVisiblePoint(double depth = -1.0) const;
+
+  /// \brief is the projection invertible?
+  bool isProjectionInvertible() const {
+    return false;
+  }
+
+  /// \brief set the distortion model.
+  void setDistortion(const distortion_t & distortion) {
+    _distortion = distortion;
+  }
+  /// \brief returns a reference to the distortion model
+  distortion_t & distortion() {
+    return _distortion;
+  }
+  ;
+  const distortion_t & distortion() const {
+    return _distortion;
+  }
+  ;
+
+  Eigen::Matrix3d getCameraMatrix() {
+    Eigen::Matrix3d K;
+    K << _fu, 0.0, _cu, 0.0, _fv, _cv, 0.0, 0.0, 1.0;
+    return K;
+  }
+  ;
+
+  /// \brief the xi parameter that controls the spherical projection.
+  double xi() const {
+    return _xi;
+  }
+  /// \brief The horizontal focal length in pixels.
+  double fu() const {
+    return _fu;
+  }
+  /// \brief The vertical focal length in pixels.
+  double fv() const {
+    return _fv;
+  }
+  /// \brief The horizontal image center in pixels.
+  double cu() const {
+    return _cu;
+  }
+  /// \brief The vertical image center in pixels.
+  double cv() const {
+    return _cv;
+  }
+  /// \brief The horizontal resolution in pixels.
+  int ru() const {
+    return _ru;
+  }
+  /// \brief The vertical resolution in pixels.
+  int rv() const {
+    return _rv;
+  }
+  /// \brief The horizontal resolution in pixels.
+  int width() const {
+    return _ru;
+  }
+  /// \brief The vertical resolution in pixels.
+  int height() const {
+    return _rv;
+  }
+
+  double focalLengthCol() const {
+    return _fu;
+  }
+  double focalLengthRow() const {
+    return _fv;
+  }
+  double opticalCenterCol() const {
+    return _cu;
+  }
+  double opticalCenterRow() const {
+    return _cv;
+  }
+
+  int keypointDimension() const {
+    return KeypointDimension;
+  }
+
+  static OmniProjection<distortion_t> getTestProjection();
+ private:
+
+  /// \brief the xi parameter that controls the spherical projection.
+  double _xi;
+  /// \brief The horizontal focal length in pixels.
+  double _fu;
+  /// \brief The vertical focal length in pixels.
+  double _fv;
+  /// \brief The horizontal image center in pixels.
+  double _cu;
+  /// \brief The vertical image center in pixels.
+  double _cv;
+  /// \brief The horizontal resolution in pixels.
+  int _ru;
+  /// \brief The vertical resolution in pixels.
+  int _rv;
+
+  /// \brief A computed value for speeding up computation.
+  void updateTemporaries();
+
+  double _recip_fu;
+  double _recip_fv;
+  double _fu_over_fv;
+  double _one_over_xixi_m_1;
+  double _fov_parameter;  //PM: is = xi for xi=<1, = 1/xi for x>1. Used for determining valid projections. Better name?
+
+  distortion_t _distortion;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/OmniProjection.hpp"
+
+
+#endif /* ASLAM_CAMERAS_OMNI_PROJECTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/PinholeProjection.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/PinholeProjection.hpp
@@ -1,0 +1,233 @@
+#ifndef ASLAM_CAMERAS_PINHOLE_PROJECTION_HPP
+#define ASLAM_CAMERAS_PINHOLE_PROJECTION_HPP
+
+namespace aslam {
+namespace cameras {
+
+template<typename DISTORTION_T>
+class PinholeProjection {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  enum {
+    KeypointDimension = 2
+  };
+
+  enum {
+    IntrinsicsDimension = 4
+  };
+  enum {
+    DesignVariableDimension = IntrinsicsDimension
+  };
+
+  typedef DISTORTION_T distortion_t;
+  typedef Eigen::Matrix<double, KeypointDimension, 1> keypoint_t;
+  typedef Eigen::Matrix<double, KeypointDimension, IntrinsicsDimension> jacobian_intrinsics_t;
+
+  /// \brief Default constructor
+  PinholeProjection();
+
+  PinholeProjection(double focalLengthU, double focalLengthV,
+                    double imageCenterU, double imageCenterV, int resolutionU,
+                    int resolutionV, distortion_t distortion);
+
+  PinholeProjection(double focalLengthU, double focalLengthV,
+                    double imageCenterU, double imageCenterV, int resolutionU,
+                    int resolutionV);
+
+  /// \brief destructor.
+  virtual ~PinholeProjection();
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool euclideanToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool euclideanToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                           const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                           const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_P, typename DERIVED_K>
+  bool homogeneousToKeypoint(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const;
+
+  template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+  bool homogeneousToKeypoint(const Eigen::MatrixBase<DERIVED_P> & p,
+                             const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+                             const Eigen::MatrixBase<DERIVED_JP> & outJp) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToEuclidean(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                           const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                           const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_K, typename DERIVED_P>
+  bool keypointToHomogeneous(
+      const Eigen::MatrixBase<DERIVED_K> & keypoint,
+      const Eigen::MatrixBase<DERIVED_P> & outPoint) const;
+
+  template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+  bool keypointToHomogeneous(const Eigen::MatrixBase<DERIVED_K> & keypoint,
+                             const Eigen::MatrixBase<DERIVED_P> & outPoint,
+                             const Eigen::MatrixBase<DERIVED_JK> & outJk) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void euclideanToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void euclideanToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_P, typename DERIVED_JI>
+  void homogeneousToKeypointIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JI> & outJi) const;
+
+  template<typename DERIVED_P, typename DERIVED_JD>
+  void homogeneousToKeypointDistortionJacobian(
+      const Eigen::MatrixBase<DERIVED_P> & p,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  template<typename DERIVED_K>
+  bool isValid(const Eigen::MatrixBase<DERIVED_K> & keypoint) const;
+
+  template<typename DERIVED_P>
+  bool isEuclideanVisible(const Eigen::MatrixBase<DERIVED_P> & p) const;
+
+  template<typename DERIVED_P>
+  bool isHomogeneousVisible(const Eigen::MatrixBase<DERIVED_P> & ph) const;
+
+  // aslam::backend compatibility
+  void update(const double * v);
+  int minimalDimensions() const;
+  void getParameters(Eigen::MatrixXd & P) const;
+  void setParameters(const Eigen::MatrixXd & P);
+  Eigen::Vector2i parameterSize() const;
+
+  // \brief creates a random valid keypoint.
+  virtual Eigen::VectorXd createRandomKeypoint() const;
+
+  // \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+  virtual Eigen::Vector3d createRandomVisiblePoint(double depth = -1.0) const;
+
+  bool isProjectionInvertible() const {
+    return false;
+  }
+
+  void setDistortion(const distortion_t & distortion) {
+    _distortion = distortion;
+  }
+  distortion_t & distortion() {
+    return _distortion;
+  }
+  ;
+  const distortion_t & distortion() const {
+    return _distortion;
+  }
+  ;
+
+  Eigen::Matrix3d getCameraMatrix() {
+    Eigen::Matrix3d K;
+    K << _fu, 0.0, _cu, 0.0, _fv, _cv, 0.0, 0.0, 1.0;
+    return K;
+  }
+  ;
+
+  double focalLengthCol() const {
+    return _fu;
+  }
+  double focalLengthRow() const {
+    return _fv;
+  }
+  double opticalCenterCol() const {
+    return _cu;
+  }
+  double opticalCenterRow() const {
+    return _cv;
+  }
+
+  /// \brief The horizontal focal length in pixels.
+  double fu() const {
+    return _fu;
+  }
+  /// \brief The vertical focal length in pixels.
+  double fv() const {
+    return _fv;
+  }
+  /// \brief The horizontal image center in pixels.
+  double cu() const {
+    return _cu;
+  }
+  /// \brief The vertical image center in pixels.
+  double cv() const {
+    return _cv;
+  }
+  /// \brief The horizontal resolution in pixels.
+  int ru() const {
+    return _ru;
+  }
+  /// \brief The vertical resolution in pixels.
+  int rv() const {
+    return _rv;
+  }
+  /// \brief The horizontal resolution in pixels.
+  int width() const {
+    return _ru;
+  }
+  /// \brief The vertical resolution in pixels.
+  int height() const {
+    return _rv;
+  }
+
+  int keypointDimension() const {
+    return KeypointDimension;
+  }
+
+  static PinholeProjection<distortion_t> getTestProjection();
+
+  /// \brief resize the intrinsics based on a scaling of the image.
+  void resizeIntrinsics(double scale);
+
+  /// \brief Get a set of border rays
+  void getBorderRays(Eigen::MatrixXd & rays);
+
+ private:
+  void updateTemporaries();
+
+  /// \brief The horizontal focal length in pixels.
+  double _fu;
+  /// \brief The vertical focal length in pixels.
+  double _fv;
+  /// \brief The horizontal image center in pixels.
+  double _cu;
+  /// \brief The vertical image center in pixels.
+  double _cv;
+  /// \brief The horizontal resolution in pixels.
+  int _ru;
+  /// \brief The vertical resolution in pixels.
+  int _rv;
+
+  /// \brief A computed value for speeding up computation.
+  double _recip_fu;
+  double _recip_fv;
+  double _fu_over_fv;
+
+  distortion_t _distortion;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/PinholeProjection.hpp"
+
+
+#endif /* ASLAM_CAMERAS_PINHOLE_PROJECTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/RadialTangentialDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/RadialTangentialDistortion.hpp
@@ -1,0 +1,168 @@
+#ifndef ASLAM_CAMERAS_RT_DISTORTION_HPP
+#define ASLAM_CAMERAS_RT_DISTORTION_HPP
+
+#include <Eigen/Dense>
+#include "StaticAssert.hpp"
+
+
+namespace aslam {
+namespace cameras {
+
+/**
+ * \class RadialTangentialDistortion
+ * \brief An implementation of the standard, four parameter distortion model for pinhole cameras.
+ *        
+ * \todo outline the math here and provide a reference. What is the original reference?
+ *
+ *
+ * The usual model of a pinhole camera follows these steps:
+ *   - Transformation: Transform the point into a coordinate frame associated with the camera
+ *   - Normalization:  Project the point onto the normalized image plane: \f$\mathbf y := \left[ x/z,y/z\right] \f$
+ *   - Distortion:     apply a nonlinear transformation to \f$y\f$ to account for radial and tangential distortion of the lens
+ *   - Projection:     Project the point into the image using a standard \f$3 \time 3\f$ projection matrix
+ *
+ * This class represents a standard implementation of the distortion block. The function "distort" applies this nonlinear transformation.
+ * The function "undistort" applies the inverse transformation. Note that the inverse transformation in this case is not avaialable in 
+ * closed form and so it is computed iteratively.
+ * 
+ */
+class RadialTangentialDistortion {
+ public:
+
+  enum {
+    IntrinsicsDimension = 4
+  };
+  enum {
+    DesignVariableDimension = IntrinsicsDimension
+  };
+
+  /// \brief The default constructor sets all values to zero. 
+  RadialTangentialDistortion();
+
+  /// \brief A constructor that initializes all values.
+  RadialTangentialDistortion(double k1, double k2, double p1, double p2);
+
+  virtual ~RadialTangentialDistortion();
+
+  /** 
+   * \brief Apply distortion to a point in the normalized image plane
+   * 
+   * @param y The point in the normalized image plane. After the function, this point is distorted.
+   */
+  template<typename DERIVED_Y>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y) const;
+
+  /** 
+   * 
+   * \brief Apply distortion to a point in the normalized image plane
+   * 
+   * @param y The point in the normalized image plane. After the function, this point is distorted.
+   * @param outJy The Jacobian of the distortion function with respect to small changes in the input point.
+   */
+  template<typename DERIVED_Y, typename DERIVED_JY>
+  void distort(const Eigen::MatrixBase<DERIVED_Y> & y,
+               const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  /** 
+   * \brief Apply undistortion to recover a point in the normalized image plane.
+   * 
+   * @param y The distorted point. After the function, this point is in the normalized image plane.
+   */
+  template<typename DERIVED>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y) const;
+
+  /** 
+   * \brief Apply undistortion to recover a point in the normalized image plane.
+   * 
+   * @param y The distorted point. After the function, this point is in the normalized image plane.
+   * @param outJy The Jacobian of the undistortion function with respect to small changes in the input point.
+   */
+  template<typename DERIVED, typename DERIVED_JY>
+  void undistort(const Eigen::MatrixBase<DERIVED> & y,
+                 const Eigen::MatrixBase<DERIVED_JY> & outJy) const;
+
+  /** 
+   * \brief Apply distortion to the point and provide the Jacobian of the distortion with respect to small changes in the distortion parameters
+   * 
+   * @param imageY the point in the normalized image plane.
+   * @param outJd  the Jacobian of the distortion with respect to small changes in the distortion parameters.
+   */
+  template<typename DERIVED_Y, typename DERIVED_JD>
+  void distortParameterJacobian(
+      const Eigen::MatrixBase<DERIVED_Y> & imageY,
+      const Eigen::MatrixBase<DERIVED_JD> & outJd) const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. This implements an update of the distortion parameter.
+   * 
+   * @param v A double array representing the update vector.
+   */
+  void update(const double * v);
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param v The number of parameters expected by the update equation. This should also define the number of columns in the matrix returned by distortParameterJacobian.
+   */
+  int minimalDimensions() const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param P This matrix is resized and filled with parameters representing the full state of the distortion. 
+   */
+  void getParameters(Eigen::MatrixXd & P) const;
+
+  /** 
+   * \brief A function for compatibility with the aslam backend. 
+   * 
+   * @param P The full state of the distortion class is set from the matrix of parameters.
+   */
+  void setParameters(const Eigen::MatrixXd & P);
+
+  Eigen::Vector2i parameterSize() const;
+
+  /// \brief the first radial distortion parameter
+  double k1() {
+    return _k1;
+  }
+  /// \brief the second radial distortion parameter
+  double k2() {
+    return _k2;
+  }
+  /// \brief the first tangential distortion parameter
+  double p1() {
+    return _p1;
+  }
+  /// \brief the second tangential distortion parameter
+  double p2() {
+    return _p2;
+  }
+
+  void clear() {
+    _k1 = 0.0;
+    _k2 = 0.0;
+    _p1 = 0.0;
+    _p2 = 0.0;
+  }
+
+  static RadialTangentialDistortion getTestDistortion();
+
+  /// \brief the first radial distortion parameter
+  double _k1;
+  /// \brief the second radial distortion parameter
+  double _k2;
+  /// \brief the first tangential distortion parameter
+  double _p1;
+  /// \brief the second tangential distortion parameter
+  double _p2;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#include "implementation/RadialTangentialDistortion.hpp"
+
+
+#endif /* ASLAM_CAMERAS_DISTORTION_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/RollingShutter.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/RollingShutter.hpp
@@ -1,0 +1,62 @@
+#ifndef ASLAM_ROLLING_SHUTTER_HPP
+#define ASLAM_ROLLING_SHUTTER_HPP
+
+#include <Eigen/Core>
+#include "Duration.hpp"
+
+
+namespace aslam {
+namespace cameras {
+
+class RollingShutter {
+
+ public:
+
+  enum {
+    DesignVariableDimension = 0
+  };
+
+  RollingShutter();
+  RollingShutter(double lineDelay);
+  ~RollingShutter();
+
+  template<typename DERIVED_K>
+  Duration temporalOffset(const Eigen::MatrixBase<DERIVED_K> & k) const {
+    return Duration(_lineDelay * k[1]);
+  }
+
+  // aslam::backend compatibility
+  void update(const double * v);
+  int minimalDimensions() const;
+  void getParameters(Eigen::MatrixXd & P) const;
+  void setParameters(const Eigen::MatrixXd & P);
+  Eigen::Vector2i parameterSize() const;
+
+  static RollingShutter getTestShutter();
+
+  double lineDelay() const {
+    return _lineDelay;
+  }
+  ;
+
+  /// The resulting jacobian assumes the output of "temporal offset" is in seconds.
+  template<typename DERIVED_K, typename DERIVED_J>
+  void temporalOffsetIntrinsicsJacobian(
+      const Eigen::MatrixBase<DERIVED_K> & k,
+      const Eigen::MatrixBase<DERIVED_J> & outJ) const {
+    Eigen::MatrixBase<DERIVED_J> & J =
+        const_cast<Eigen::MatrixBase<DERIVED_J> &>(outJ);
+    J.resize(1, 1);
+    J(0, 0) = k[1];
+  }
+
+ private:
+  // RS camera time between start of integration of two consecutive lines in seconds
+  double _lineDelay;
+
+};
+
+}  // namespace cameras
+}  // namespace aslam
+
+#endif /* ASLAM_ROLLING_SHUTTER_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/StaticAssert.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/StaticAssert.hpp
@@ -1,0 +1,16 @@
+#ifndef ASLAM_EIGEN_STATIC_ASSERT_HPP
+#define ASLAM_EIGEN_STATIC_ASSERT_HPP
+
+#include <Eigen/Core>
+
+// static assertion failing if the type \a TYPE is not a vector type of the given size
+#define EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(TYPE, SIZE) \
+  EIGEN_STATIC_ASSERT(TYPE::IsVectorAtCompileTime && (TYPE::SizeAtCompileTime==SIZE || TYPE::SizeAtCompileTime==Eigen::Dynamic), \
+					  THIS_METHOD_IS_ONLY_FOR_VECTORS_OF_A_SPECIFIC_SIZE)
+
+// static assertion failing if the type \a TYPE is not a vector type of the given size
+#define EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(TYPE, ROWS, COLS) \
+  EIGEN_STATIC_ASSERT( (TYPE::RowsAtCompileTime==ROWS || TYPE::RowsAtCompileTime==Eigen::Dynamic) && (TYPE::ColsAtCompileTime==COLS || TYPE::RowsAtCompileTime==Eigen::Dynamic), \
+					   THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE)
+
+#endif /* SM_EIGEN_STATIC_ASSERT_HPP */

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/CameraGeometry.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/CameraGeometry.hpp
@@ -1,0 +1,681 @@
+#include <iostream>
+
+namespace aslam {
+
+  namespace cameras {
+
+    /// \brief default constructor
+    template<typename P, typename S, typename M>
+    CameraGeometry<P, S, M>::CameraGeometry() {
+
+    }
+
+    /// \brief Construct from projection
+    template<typename P, typename S, typename M>
+    CameraGeometry<P, S, M>::CameraGeometry(const projection_t & projection)
+        : _projection(projection) {
+
+    }
+
+    /// \brief Construct from projection and shutter
+    template<typename P, typename S, typename M>
+    CameraGeometry<P, S, M>::CameraGeometry(const projection_t & projection,
+                                            const shutter_t & shutter)
+        : _projection(projection),
+          _shutter(shutter) {
+
+    }
+
+    /// \brief Construct from projection, shutter, and mask
+    template<typename P, typename S, typename M>
+    CameraGeometry<P, S, M>::CameraGeometry(const projection_t & projection,
+                                            const shutter_t & shutter,
+                                            const mask_t & mask)
+        : _projection(projection),
+          _shutter(shutter),
+          _mask(mask) {
+
+    }
+
+    /// \brief simple destructor
+    template<typename P, typename S, typename M>
+    CameraGeometry<P, S, M>::~CameraGeometry() {
+
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsEuclideanToKeypoint(
+        const Eigen::Vector3d & p, Eigen::VectorXd & outKeypoint) const {
+      bool valid = _projection.euclideanToKeypoint(p, outKeypoint);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsEuclideanToKeypoint(
+        const Eigen::Vector3d & p, Eigen::VectorXd & outKeypoint,
+        Eigen::MatrixXd & outJacobian) const {
+      bool valid = _projection.euclideanToKeypoint(p, outKeypoint, outJacobian);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsHomogeneousToKeypoint(
+        const Eigen::Vector4d & ph, Eigen::VectorXd & outKeypoint) const {
+      bool valid = _projection.homogeneousToKeypoint(ph, outKeypoint);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsHomogeneousToKeypoint(
+        const Eigen::Vector4d & ph, Eigen::VectorXd & outKeypoint,
+        Eigen::MatrixXd & outJacobian) const {
+      bool valid = _projection.homogeneousToKeypoint(ph, outKeypoint, outJacobian);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsKeypointToEuclidean(
+        const Eigen::VectorXd & keypoint, Eigen::Vector3d & outPoint) const {
+      return _projection.keypointToEuclidean(keypoint, outPoint)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsKeypointToEuclidean(
+        const Eigen::VectorXd & keypoint, Eigen::VectorXd & outPoint,
+        Eigen::MatrixXd & outJacobian) const {
+      return _projection.keypointToEuclidean(keypoint, outPoint, outJacobian)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsKeypointToHomogeneous(
+        Eigen::VectorXd const & keypoint, Eigen::VectorXd & outPoint) const {
+      return _projection.keypointToHomogeneous(keypoint, outPoint)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsKeypointToHomogeneous(
+        Eigen::VectorXd const & keypoint, Eigen::VectorXd & outPoint,
+        Eigen::MatrixXd & outJacobian) const {
+      return _projection.keypointToHomogeneous(keypoint, outPoint, outJacobian)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsIsValid(
+        const Eigen::VectorXd & keypoint) const {
+      return isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsIsEuclideanVisible(
+        const Eigen::Vector3d & p) const {
+      return _projection.isEuclideanVisible(p);
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::vsIsHomogeneousVisible(
+        const Eigen::Vector4d & ph) const {
+      return _projection.isHomogeneousVisible(ph);
+    }
+
+    // The amount of time elapsed between the start of the image and the
+    // keypoint. For a global shutter camera, this can return Duration(0).
+    template<typename P, typename S, typename M>
+    Duration CameraGeometry<P, S, M>::vsTemporalOffset(
+        const Eigen::VectorXd & keypoint) const {
+      return _shutter.temporalOffset(keypoint);
+    }
+
+    /// \brief the length of a keypoint
+    template<typename P, typename S, typename M>
+    size_t CameraGeometry<P, S, M>::keypointDimension() const {
+      return P::KeypointDimension;
+    }
+
+    // \brief creates a random valid keypoint.
+    template<typename P, typename S, typename M>
+    Eigen::VectorXd CameraGeometry<P, S, M>::createRandomKeypoint() const {
+      return _projection.createRandomKeypoint();
+    }
+
+    // \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+    template<typename P, typename S, typename M>
+    Eigen::Vector3d CameraGeometry<P, S, M>::createRandomVisiblePoint(
+        double depth) const {
+      return _projection.createRandomVisiblePoint(depth);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_K>
+    bool CameraGeometry<P, S, M>::euclideanToKeypoint(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const {
+      bool valid = _projection.euclideanToKeypoint(p, outKeypoint);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+    bool CameraGeometry<P, S, M>::euclideanToKeypoint(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+        const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+      bool valid = _projection.euclideanToKeypoint(p, outKeypoint, outJp);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+    bool CameraGeometry<P, S, M>::euclideanToKeypointFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+        const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+      DERIVED_JP & Jp = const_cast<Eigen::MatrixBase<DERIVED_JP>&>(outJp).derived();
+      ASLAM_CAMERAS_ESTIMATE_JACOBIAN(this, euclideanToKeypoint, p, 1e-5, Jp);
+
+      bool valid = _projection.euclideanToKeypoint(p, outKeypoint);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_K>
+    bool CameraGeometry<P, S, M>::homogeneousToKeypoint(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const {
+      bool valid = _projection.homogeneousToKeypoint(p, outKeypoint);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+    bool CameraGeometry<P, S, M>::homogeneousToKeypoint(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+        const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+      bool valid = _projection.homogeneousToKeypoint(p, outKeypoint, outJp);
+      return valid && _mask.isValid(outKeypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+    bool CameraGeometry<P, S, M>::homogeneousToKeypointFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+        const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+      DERIVED_JP & Jp = const_cast<Eigen::MatrixBase<DERIVED_JP>&>(outJp).derived();
+      ASLAM_CAMERAS_ESTIMATE_JACOBIAN(this, homogeneousToKeypoint, p, 1e-5, Jp);
+
+      return _mask.isValid(_projection.homogeneousToKeypoint(p, outKeypoint));
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K, typename DERIVED_P>
+    bool CameraGeometry<P, S, M>::keypointToEuclidean(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint,
+        const Eigen::MatrixBase<DERIVED_P> & outPoint) const {
+      // I'm putting the mask second in this case to make sure the keypointToEuclidean function is called.
+      return _projection.keypointToEuclidean(keypoint, outPoint)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+    bool CameraGeometry<P, S, M>::keypointToEuclidean(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint,
+        const Eigen::MatrixBase<DERIVED_P> & outPoint,
+        const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+      // I'm putting the mask second in this case to make sure the keypointToEuclidean function is called.
+      return _projection.keypointToEuclidean(keypoint, outPoint, outJk)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+    bool CameraGeometry<P, S, M>::keypointToEuclideanFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint,
+        const Eigen::MatrixBase<DERIVED_P> & outPoint,
+        const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+      DERIVED_JK & Jk = const_cast<Eigen::MatrixBase<DERIVED_JK>&>(outJk).derived();
+      ASLAM_CAMERAS_ESTIMATE_JACOBIAN(this, keypointToEuclidean, keypoint, 1e-5,
+                                      Jk);
+
+      // I'm putting the mask second in this case to make sure the keypointToEuclidean function is called.
+      return _projection.keypointToEuclidean(keypoint, outPoint)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K, typename DERIVED_P>
+    bool CameraGeometry<P, S, M>::keypointToHomogeneous(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint,
+        const Eigen::MatrixBase<DERIVED_P> & outPoint) const {
+      // I'm putting the mask second in this case to make sure the keypointToEuclidean function is called.
+      return _projection.keypointToHomogeneous(keypoint, outPoint)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+    bool CameraGeometry<P, S, M>::keypointToHomogeneous(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint,
+        const Eigen::MatrixBase<DERIVED_P> & outPoint,
+        const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+      // I'm putting the mask second in this case to make sure the keypointToEuclidean function is called.
+      return _projection.keypointToHomogeneous(keypoint, outPoint, outJk)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+    bool CameraGeometry<P, S, M>::keypointToHomogeneousFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint,
+        const Eigen::MatrixBase<DERIVED_P> & outPoint,
+        const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+      DERIVED_JK & Jk = const_cast<Eigen::MatrixBase<DERIVED_JK>&>(outJk).derived();
+      ASLAM_CAMERAS_ESTIMATE_JACOBIAN(this, keypointToHomogeneous, keypoint, 1e-5,
+                                      Jk);
+
+      // I'm putting the mask second in this case to make sure the keypointToEuclidean function is called.
+      return _projection.keypointToHomogeneous(keypoint, outPoint)
+          && _mask.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JI>
+    void CameraGeometry<P, S, M>::euclideanToKeypointIntrinsicsJacobian(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+      _projection.euclideanToKeypointIntrinsicsJacobian(p, outJi);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JD>
+    void CameraGeometry<P, S, M>::euclideanToKeypointDistortionJacobian(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+      _projection.euclideanToKeypointDistortionJacobian(p, outJd);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JI>
+    void CameraGeometry<P, S, M>::homogeneousToKeypointIntrinsicsJacobian(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+      _projection.homogeneousToKeypointIntrinsicsJacobian(p, outJi);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JD>
+    void CameraGeometry<P, S, M>::homogeneousToKeypointDistortionJacobian(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+      return _projection.homogeneousToKeypointDistortionJacobian(p, outJd);
+    }
+
+    // template<typename P, typename S, typename M>
+    // template<typename DERIVED_P, typename DERIVED_JD>
+    // void CameraGeometry<P, S, M>::homogeneousToKeypointShutterJacobian(
+    //     const Eigen::MatrixBase<DERIVED_P> & p,
+    //     const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+    //   return _shutter.homogeneousToKeypointShutterJacobian(p, outJd);
+    // }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JI>
+    void CameraGeometry<P, S, M>::euclideanToKeypointIntrinsicsJacobianFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+      DERIVED_JI & Ji = const_cast<Eigen::MatrixBase<DERIVED_JI>&>(outJi).derived();
+      projection_t proj = _projection;
+      ASLAM_CAMERAS_ESTIMATE_INTRINSIC_JACOBIAN(euclideanToKeypoint, proj, proj, p,
+                                                1e-5, Ji);
+
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JI>
+    void CameraGeometry<P, S, M>::homogeneousToKeypointIntrinsicsJacobianFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+      DERIVED_JI & Ji = const_cast<Eigen::MatrixBase<DERIVED_JI>&>(outJi).derived();
+      projection_t proj = _projection;
+      ASLAM_CAMERAS_ESTIMATE_INTRINSIC_JACOBIAN(homogeneousToKeypoint, proj, proj,
+                                                p, 1e-5, Ji);
+
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JD>
+    void CameraGeometry<P, S, M>::euclideanToKeypointDistortionJacobianFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+      DERIVED_JD & Jd = const_cast<Eigen::MatrixBase<DERIVED_JD>&>(outJd).derived();
+      projection_t proj = _projection;
+      ASLAM_CAMERAS_ESTIMATE_INTRINSIC_JACOBIAN(euclideanToKeypoint, proj,
+                                                proj.distortion(), p, 1e-5, Jd);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P, typename DERIVED_JD>
+    void CameraGeometry<P, S, M>::homogeneousToKeypointDistortionJacobianFiniteDifference(
+        const Eigen::MatrixBase<DERIVED_P> & p,
+        const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+      DERIVED_JD & Jd = const_cast<Eigen::MatrixBase<DERIVED_JD>&>(outJd).derived();
+      projection_t proj = _projection;
+      ASLAM_CAMERAS_ESTIMATE_INTRINSIC_JACOBIAN(homogeneousToKeypoint, proj,
+                                                proj.distortion(), p, 1e-5, Jd);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // SHUTTER SUPPORT
+    //////////////////////////////////////////////////////////////
+
+    // The amount of time elapsed between the start of the image and the
+    // keypoint. For a global shutter camera, this can return CameraGeometry<P,S,M>::Duration(0).
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K>
+    Duration CameraGeometry<P, S, M>::temporalOffset(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint) const {
+      return _shutter.temporalOffset(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    Duration CameraGeometry<P, S, M>::temporalOffset(
+        const Eigen::VectorXd& keypoint) const {
+      return _shutter.temporalOffset(keypoint);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // VALIDITY TESTING
+    //////////////////////////////////////////////////////////////
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_K>
+    bool CameraGeometry<P, S, M>::isValid(
+        const Eigen::MatrixBase<DERIVED_K> & keypoint) const {
+      return _mask.isValid(keypoint) && _projection.isValid(keypoint);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P>
+    bool CameraGeometry<P, S, M>::isEuclideanVisible(
+        const Eigen::MatrixBase<DERIVED_P> & p) const {
+      keypoint_t k;
+      bool success = _projection.euclideanToKeypoint(p, k);
+
+      return success && _mask.isValid(k);
+    }
+
+    template<typename P, typename S, typename M>
+    template<typename DERIVED_P>
+    bool CameraGeometry<P, S, M>::isHomogeneousVisible(
+        const Eigen::MatrixBase<DERIVED_P> & ph) const {
+      keypoint_t k;
+      bool success = _projection.homogeneousToKeypoint(ph, k);
+
+      return success && _mask.isValid(k);
+
+    }
+
+    template<typename P, typename S, typename M>
+    bool CameraGeometry<P, S, M>::isProjectionInvertible() const {
+      return _projection.isProjectionInvertible();
+    }
+
+    template<typename P, typename S, typename M>
+    CameraGeometry<P, S, M> CameraGeometry<P, S, M>::getTestGeometry() {
+      CameraGeometry<P, S, M> camera(projection_t::getTestProjection(),
+                                     shutter_t::getTestShutter(), mask_t());
+      return camera;
+    }
+
+    /// \brief initialize the intrinsics based on list of views of a gridded calibration target
+
+  template<typename PP, typename S, typename M>
+    void CameraGeometry<PP, S, M>::print(std::ostream & out) {
+      std::cout << "Printing!\n";
+      Eigen::MatrixXd P;
+      _projection.getParameters(P);
+      out << "Projection: " << P.transpose() << std::endl;
+      _projection.distortion().getParameters(P);
+      if (P.rows() > 0 && P.cols() > 0) {
+        out << "Distortion: " << P.transpose() << std::endl;
+      }
+    }
+
+    /// \brief the minimal dimensions of the projection parameters
+    template<typename P, typename S, typename M>
+    int CameraGeometry<P, S, M>::minimalDimensionsProjection() const {
+      return _projection.minimalDimensions();
+    }
+
+    /// \brief the minimal dimensions of the distortion parameters
+    template<typename P, typename S, typename M>
+    int CameraGeometry<P, S, M>::minimalDimensionsDistortion() const {
+      return _projection.distortion().minimalDimensions();
+    }
+
+    template<typename P, typename S, typename M>
+    int CameraGeometry<P, S, M>::minimalDimensionsShutter() const {
+      return _shutter.minimalDimensions();
+    }
+
+    /// \brief update the intrinsics
+    template<typename P, typename S, typename M>
+    void CameraGeometry<P, S, M>::update(const double * v, bool estimateProjection,
+                                         bool estimateDistortion,
+                                         bool estimateShutter) {
+      if (estimateProjection) {
+        _projection.update(v);
+        v += _projection.minimalDimensions();
+      }
+
+      if (estimateDistortion) {
+        _projection.distortion().update(v);
+        v += _projection.distortion().minimalDimensions();
+      }
+
+      if (estimateShutter) {
+        _shutter.update(v);
+      }
+    }
+
+    /// \brief Get the total number of dimensions of the intrinsic parameters
+    template<typename P, typename S, typename M>
+    int CameraGeometry<P, S, M>::minimalDimensions(bool estimateProjection,
+                                                   bool estimateDistortion,
+                                                   bool estimateShutter) const {
+      int dim = 0;
+      if (estimateProjection) {
+        dim += _projection.minimalDimensions();
+      }
+
+      if (estimateDistortion) {
+        dim += _projection.distortion().minimalDimensions();
+      }
+
+      if (estimateShutter) {
+        dim += _shutter.minimalDimensions();
+      }
+      return dim;
+    }
+
+    /// \brief get the intrinsic parameters.
+    template<typename P, typename S, typename M>
+    void CameraGeometry<P, S, M>::getParameters(Eigen::MatrixXd & params,
+                                                bool estimateProjection,
+                                                bool estimateDistortion,
+                                                bool estimateShutter) const {
+      Eigen::MatrixXd Pp, Pd, Ps;
+      int rows = 0, cols = 0;
+      if (estimateProjection) {
+        _projection.getParameters(Pp);
+        rows += Pp.rows();
+        cols = std::max(cols, (int) Pp.cols());
+      }
+
+      if (estimateDistortion) {
+        _projection.distortion().getParameters(Pd);
+        rows += Pd.rows();
+        cols = std::max(cols, (int) Pd.cols());
+      }
+
+      if (estimateShutter) {
+        _shutter.getParameters(Ps);
+        rows += Ps.rows();
+        cols = std::max(cols, (int) Ps.cols());
+      }
+
+      params = Eigen::MatrixXd::Zero(rows, cols);
+      int row = 0;
+
+      if (estimateProjection) {
+        params.block(row, 0, Pp.rows(), Pp.cols()) = Pp;
+        row += Pp.rows();
+      }
+
+      if (estimateDistortion) {
+        params.block(row, 0, Pd.rows(), Pd.cols()) = Pd;
+        row += Pd.rows();
+      }
+
+      if (estimateShutter) {
+        params.block(row, 0, Ps.rows(), Ps.cols()) = Ps;
+        row += Ps.rows();
+      }
+
+    }
+
+    /// \brief set the intrinsic parameters.
+    template<typename P, typename S, typename M>
+    void CameraGeometry<P, S, M>::setParameters(const Eigen::MatrixXd & params,
+                                                bool estimateProjection,
+                                                bool estimateDistortion,
+                                                bool estimateShutter) {
+      // Ugh...I wish I had used a vector, not a matrix.
+      int row = 0;
+      if (estimateProjection) {
+        Eigen::Vector2i sz = _projection.parameterSize();
+        _projection.setParameters(params.block(row, 0, sz[0], sz[1]));
+        row += sz[0];
+      }
+
+      if (estimateDistortion) {
+        Eigen::Vector2i sz = _projection.distortion().parameterSize();
+        _projection.distortion().setParameters(params.block(row, 0, sz[0], sz[1]));
+        row += sz[0];
+      }
+
+      if (estimateShutter) {
+        Eigen::Vector2i sz = _shutter.parameterSize();
+        _shutter.setParameters(params.block(row, 0, sz[0], sz[1]));
+        row += sz[0];
+      }
+
+    }
+
+    /// \brief return the Jacobian of the projection with respect to the intrinsics.
+    template<typename P, typename S, typename M>
+    void CameraGeometry<P, S, M>::euclideanToKeypointIntrinsicsJacobian(
+        const Eigen::Vector3d & p, Eigen::MatrixXd & outJi, bool estimateProjection,
+        bool estimateDistortion, bool estimateShutter) const {
+      // Here I have to stack the answers. The resulting matrix should be
+      // KeypointDimension x minimalDimensions()
+      outJi = Eigen::MatrixXd::Zero(
+          KeypointDimension,
+          minimalDimensions(estimateProjection, estimateDistortion,
+                            estimateShutter));
+
+      int col = 0;
+      if (estimateProjection) {
+        Eigen::MatrixXd J;
+        _projection.euclideanToKeypointIntrinsicsJacobian(p, J);
+        outJi.block(col, 0, KeypointDimension, _projection.minimalDimensions()) = J;
+        col += _projection.minimalDimensions();
+      }
+
+      if (estimateDistortion) {
+        Eigen::MatrixXd J;
+        _projection.euclideanToKeypointDistortionJacobian(p, J);
+        outJi.block(col, 0, KeypointDimension,
+                    _projection.distortion().minimalDimensions()) = J;
+        col += _projection.distortion().minimalDimensions();
+      }
+
+      if (estimateShutter) {
+        // Uh...nothing. The shutter acts on the keypoint time.
+        // At least for any example I can think of.
+      }
+
+    }
+
+    /// \brief return the Jacobian of the projection with respect to the intrinsics.
+    template<typename P, typename S, typename M>
+    void CameraGeometry<P, S, M>::homogeneousToKeypointIntrinsicsJacobian(
+        const Eigen::Vector4d & p, Eigen::MatrixXd & outJi, bool estimateProjection,
+        bool estimateDistortion, bool estimateShutter) const {
+      // Here I have to stack the answers. The resulting matrix should be
+      // KeypointDimension x minimalDimensions()
+      outJi = Eigen::MatrixXd::Zero(
+          KeypointDimension,
+          minimalDimensions(estimateProjection, estimateDistortion,
+                            estimateShutter));
+
+      int col = 0;
+      if (estimateProjection) {
+        Eigen::MatrixXd J;
+        _projection.homogeneousToKeypointIntrinsicsJacobian(p, J);
+        outJi.block(0, col, KeypointDimension, _projection.minimalDimensions()) = J;
+        col += _projection.minimalDimensions();
+      }
+
+      if (estimateDistortion) {
+        Eigen::MatrixXd J;
+        _projection.homogeneousToKeypointDistortionJacobian(p, J);
+        outJi.block(0, col, KeypointDimension,
+                    _projection.distortion().minimalDimensions()) = J;
+        col += _projection.distortion().minimalDimensions();
+      }
+
+      if (estimateShutter) {
+        // Uh...nothing. The shutter acts on the keypoint time.
+        // At least for any example I can think of.
+      }
+
+    }
+
+    /// \brief return the temporal offset with respect to the intrinsics.
+    template<typename P, typename S, typename M>
+    void CameraGeometry<P, S, M>::temporalOffsetIntrinsicsJacobian(
+        const Eigen::VectorXd & keypoint, Eigen::MatrixXd & outJi,
+        bool estimateProjection, bool estimateDistortion,
+        bool estimateShutter) const {
+      // Here I have to stack the answers. The resulting matrix should be
+      // 1 x totalparameterSize
+      outJi = Eigen::MatrixXd::Zero(
+          1,
+          minimalDimensions(estimateProjection, estimateDistortion,
+                            estimateShutter));
+
+      int col = 0;
+      if (estimateProjection) {
+        col += _projection.minimalDimensions();
+      }
+
+      if (estimateDistortion) {
+        col += _projection.distortion().minimalDimensions();
+      }
+
+      if (estimateShutter) {
+        _shutter.temporalOffsetIntrinsicsJacobian(
+            keypoint, outJi.block(0, col, 1, _shutter.minimalDimensions()));
+      }
+    }
+
+  }  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/DepthProjection.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/DepthProjection.hpp
@@ -1,0 +1,503 @@
+namespace aslam {
+
+namespace cameras {
+
+template<typename DISTORTION_T>
+DepthProjection<DISTORTION_T>::DepthProjection()
+    : _fu(400),
+      _fv(400),
+      _cu(320),
+      _cv(240),
+      _ru(640),
+      _rv(480),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv) {
+
+}
+
+template<typename DISTORTION_T>
+DepthProjection<DISTORTION_T>::DepthProjection(distortion_t distortion)
+    : _fu(400),
+      _fv(400),
+      _cu(320),
+      _cv(240),
+      _ru(640),
+      _rv(480),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv),
+      _distortion(distortion) {
+
+}
+
+template<typename DISTORTION_T>
+DepthProjection<DISTORTION_T>::DepthProjection(double focalLengthU,
+                                               double focalLengthV,
+                                               double imageCenterU,
+                                               double imageCenterV,
+                                               int resolutionU, int resolutionV,
+                                               distortion_t distortion)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv),
+      _distortion(distortion) {
+  // 0
+}
+
+template<typename DISTORTION_T>
+DepthProjection<DISTORTION_T>::DepthProjection(double focalLengthU,
+                                               double focalLengthV,
+                                               double imageCenterU,
+                                               double imageCenterV,
+                                               int resolutionU, int resolutionV)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv) {
+
+}
+
+template<typename DISTORTION_T>
+DepthProjection<DISTORTION_T>::~DepthProjection() {
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K>
+bool DepthProjection<DISTORTION_T>::euclideanToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypointConst) const {
+  /// \todo
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+  Eigen::MatrixBase<DERIVED_K> & outKeypoint = const_cast<Eigen::MatrixBase<
+      DERIVED_K> &>(outKeypointConst);
+
+  outKeypoint.derived().resize(3);
+  double rz = 1.0 / p[2];
+  outKeypoint[0] = p[0] * rz;
+  outKeypoint[1] = p[1] * rz;
+  outKeypoint[2] = rz;
+
+  //_distortion.distort(outKeypoint);
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+
+  return isValid(outKeypoint) && p[2] > 0;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+bool DepthProjection<DISTORTION_T>::euclideanToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypointConst,
+    const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JP>, 3, 3);
+  /// \todo
+  Eigen::MatrixBase<DERIVED_K> & outKeypoint = const_cast<Eigen::MatrixBase<
+      DERIVED_K> &>(outKeypointConst);
+  outKeypoint.derived().resize(3);
+
+  // Jacobian:
+  Eigen::MatrixBase<DERIVED_JP> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JP> &>(outJp);
+  J.derived().resize(KeypointDimension, 3);
+  J.setZero();
+
+  double rz = 1.0 / p[2];
+  double rz2 = rz * rz;
+  outKeypoint[0] = p[0] * rz;
+  outKeypoint[1] = p[1] * rz;
+  outKeypoint[2] = rz;
+
+  Eigen::MatrixXd Jd;
+  //_distortion.distort(outKeypoint, Jd);
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+
+  // Jacobian including distortion
+  J(0, 0) = _fu * Jd(0, 0) * rz;
+  J(0, 1) = _fu * Jd(0, 1) * rz;
+  J(0, 2) = -_fu * (p[0] * Jd(0, 0) + p[1] * Jd(0, 1)) * rz2;
+  J(1, 0) = _fv * Jd(1, 0) * rz;
+  J(1, 1) = _fv * Jd(1, 1) * rz;
+  J(1, 2) = -_fv * (p[0] * Jd(1, 0) + p[1] * Jd(1, 1)) * rz2;
+
+  /// \todo does the distortion affect the depth?
+  J(2, 2) = -rz2;
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+
+  return isValid(outKeypoint) && p[2] > 0;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K>
+bool DepthProjection<DISTORTION_T>::homogeneousToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & ph,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const {
+  /// \todo this class now assumes (as the pinhole projection class) that a homogeneous point ph has p[3] == 0!
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+
+  // hope this works... (required to have valid static asserts)
+  if (ph[3] < 0)
+    return euclideanToKeypoint(-ph.derived().template head<3>(), outKeypoint);
+  else
+    return euclideanToKeypoint(ph.derived().template head<3>(), outKeypoint);
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+bool DepthProjection<DISTORTION_T>::homogeneousToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & ph,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+    const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JP>, 3, 4);
+
+  Eigen::MatrixBase<DERIVED_JP> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JP> &>(outJp);
+  J.derived().resize(KeypointDimension, 4);
+  J.setZero();
+
+  // hope this works... (required to have valid static asserts)
+  return euclideanToKeypoint(
+      ph.derived().template head<3>(), outKeypoint,
+      J.derived().template topLeftCorner<KeypointDimension, 3>());
+
+  if (ph[3] < 0)
+    return euclideanToKeypoint(
+        ph.derived().template head<3>(), outKeypoint,
+        J.derived().template topLeftCorner<KeypointDimension, 3>());
+  else
+    return euclideanToKeypoint(
+        ph.derived().template head<3>(), outKeypoint,
+        J.derived().template topLeftCorner<KeypointDimension, 3>());
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P>
+bool DepthProjection<DISTORTION_T>::keypointToEuclidean(
+    const Eigen::MatrixBase<DERIVED_K> & /* keypoint */,
+    const Eigen::MatrixBase<DERIVED_P> & /* outPointConst */) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+  /// \todo
+  //keypoint_t kp = keypoint;
+  /*
+   kp[0] = (kp[0] - _cu) / _fu;
+   kp[1] = (kp[1] - _cv) / _fv;
+   _distortion.undistort(kp); // revert distortion
+
+   Eigen::MatrixBase<DERIVED_P> & outPoint = const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPointConst);
+   outPoint.derived().resize(3);
+
+   outPoint[0] = kp[0];
+   outPoint[1] = kp[1];
+   outPoint[2] = 1;
+   */
+  return false;  //isValid(keypoint);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+bool DepthProjection<DISTORTION_T>::keypointToEuclidean(
+    const Eigen::MatrixBase<DERIVED_K> & /* keypoint */,
+    const Eigen::MatrixBase<DERIVED_P> & /* outPointConst */,
+    const Eigen::MatrixBase<DERIVED_JK> & /* outJk */) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JK>, 3, 3);
+  /// \todo
+  //keypoint_t kp = keypoint;
+  /*
+   kp[0] = (kp[0] - _cu) / _fu;
+   kp[1] = (kp[1] - _cv) / _fv;
+
+   Eigen::MatrixXd Jd(2, 2);
+
+   _distortion.undistort(kp, Jd); // revert distortion
+
+   Eigen::MatrixBase<DERIVED_P> & outPoint = const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPointConst);
+   outPoint.derived().resize(3);
+
+   outPoint[0] = kp[0];
+   outPoint[1] = kp[1];
+   outPoint[2] = 1;
+
+   Eigen::MatrixBase<DERIVED_JK> & J = const_cast<Eigen::MatrixBase<DERIVED_JK> &>(outJk);
+   J.derived().resize(3,KeypointDimension);
+   J.setZero();
+
+   //J.derived()(0,0) = 1.0;
+   //J.derived()(1,1) = _fu_over_fv;
+
+   J.derived()(0,0) = _recip_fu;
+   J.derived()(1,1) = _recip_fv;
+
+   J *= Jd;
+   */
+  return false;	  //isValid(keypoint);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P>
+bool DepthProjection<DISTORTION_T>::keypointToHomogeneous(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPoint) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+
+  Eigen::MatrixBase<DERIVED_P> & p =
+      const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPoint);
+  p.derived().resize(4);
+  p[3] = 1.0;
+  return keypointToEuclidean(keypoint, p.derived().template head<3>());
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+bool DepthProjection<DISTORTION_T>::keypointToHomogeneous(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPoint,
+    const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JK>, 4, 3);
+
+  Eigen::MatrixBase<DERIVED_JK> & Jk =
+      const_cast<Eigen::MatrixBase<DERIVED_JK> &>(outJk);
+  Jk.derived().resize(KeypointDimension, 4);
+  Jk.setZero();
+
+  Eigen::MatrixBase<DERIVED_P> & p =
+      const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPoint);
+  p[3] = 1.0;
+
+  return keypointToEuclidean(keypoint, p.template head<3>(),
+                             Jk.template topLeftCorner<3, KeypointDimension>());
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JI>
+void DepthProjection<DISTORTION_T>::euclideanToKeypointIntrinsicsJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & /* p */,
+    const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JI>, 3, 4);
+  /// \todo
+  Eigen::MatrixBase<DERIVED_JI> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JI> &>(outJi);
+  J.derived().resize(KeypointDimension, 4);
+  J.setZero();
+  /*
+   double rz = 1.0/p[2];
+
+   keypoint_t kp;
+   kp[0] = p[0] * rz;
+   kp[1] = p[1] * rz;
+   _distortion.distort(kp);
+
+   J(0,0) = kp[0];
+   J(0,2) = 1;
+
+   J(1,1) = kp[1];
+   J(1,3) = 1;*/
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JD>
+void DepthProjection<DISTORTION_T>::euclideanToKeypointDistortionJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & /* p */,
+    const Eigen::MatrixBase<DERIVED_JD> & /* outJd */) const {
+  /// \todo
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  /*
+   double rz = 1.0/p[2];
+   keypoint_t kp;
+   kp[0] = p[0] * rz;
+   kp[1] = p[1] * rz;
+
+   _distortion.distortParameterJacobian(kp, outJd);
+
+   Eigen::MatrixBase<DERIVED_JD> & J = const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+   J.derived().resize(KeypointDimension, _distortion.minimalDimensions());
+
+   J.row(0) *= _fu;
+   J.row(1) *= _fv;*/
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JI>
+void DepthProjection<DISTORTION_T>::homogeneousToKeypointIntrinsicsJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & /* p */,
+    const Eigen::MatrixBase<DERIVED_JI> & /* outJi */) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JI>, 3, 4);
+
+  SM_THROW(std::runtime_error, "Not Implemented");
+  //euclideanToKeypointIntrinsicsJacobian(p.derived().template head<3>()(0,3), outJi);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JD>
+void DepthProjection<DISTORTION_T>::homogeneousToKeypointDistortionJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+
+  euclideanToKeypointDistortionJacobian(p.derived().template head<3>(), outJd);
+
+}
+
+// \brief creates a random valid keypoint.
+template<typename DISTORTION_T>
+Eigen::VectorXd DepthProjection<DISTORTION_T>::createRandomKeypoint() const {
+  /// \todo
+  return Eigen::VectorXd::Zero(KeypointDimension);
+}
+
+// \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+template<typename DISTORTION_T>
+Eigen::Vector3d DepthProjection<DISTORTION_T>::createRandomVisiblePoint(
+    double /* depth */) const {
+  /// \todo
+  return Eigen::VectorXd::Zero(3);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K>
+bool DepthProjection<DISTORTION_T>::isValid(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint) const {
+  /// \todo
+  return keypoint[0] >= 0 && keypoint[1] >= 0 && keypoint[0] < (double) _ru
+      && keypoint[1] < (double) _rv;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P>
+bool DepthProjection<DISTORTION_T>::isEuclideanVisible(
+    const Eigen::MatrixBase<DERIVED_P> & p) const {
+  /// \todo
+  keypoint_t k;
+  return euclideanToKeypoint(p, k);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P>
+bool DepthProjection<DISTORTION_T>::isHomogeneousVisible(
+    const Eigen::MatrixBase<DERIVED_P> & ph) const {
+  /// \todo
+  keypoint_t k;
+  return homogeneousToKeypoint(ph, k);
+}
+
+template<typename DISTORTION_T>
+void DepthProjection<DISTORTION_T>::update(const double * v) {
+  _fu += v[0];
+  _fv += v[1];
+  _cu += v[2];
+  _cv += v[3];
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+}
+
+template<typename DISTORTION_T>
+int DepthProjection<DISTORTION_T>::minimalDimensions() const {
+  return IntrinsicsDimension;
+}
+
+template<typename DISTORTION_T>
+Eigen::Vector2i DepthProjection<DISTORTION_T>::parameterSize() const {
+  return Eigen::Vector2i(4, 1);
+}
+
+template<typename DISTORTION_T>
+void DepthProjection<DISTORTION_T>::getParameters(Eigen::MatrixXd & P) const {
+  P.resize(4, 1);
+  P(0, 0) = _fu;
+  P(1, 0) = _fv;
+  P(2, 0) = _cu;
+  P(3, 0) = _cv;
+}
+
+template<typename DISTORTION_T>
+void DepthProjection<DISTORTION_T>::setParameters(const Eigen::MatrixXd & P) {
+  _fu = P(0, 0);
+  _fv = P(1, 0);
+  _cu = P(2, 0);
+  _cv = P(3, 0);
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+}
+
+}
+
+}

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/EquidistantDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/EquidistantDistortion.hpp
@@ -1,0 +1,298 @@
+namespace aslam {
+namespace cameras {
+
+template<typename DERIVED_Y>
+void EquidistantDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & yconst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+
+  Eigen::MatrixBase<DERIVED_Y> & y =
+      const_cast<Eigen::MatrixBase<DERIVED_Y> &>(yconst);
+  y.derived().resize(2);
+
+  double r, theta, theta2, theta4, theta6, theta8, thetad, scaling;
+
+  r = sqrt(y[0] * y[0] + y[1] * y[1]);
+  theta = atan(r);
+  theta2 = theta * theta;
+  theta4 = theta2 * theta2;
+  theta6 = theta4 * theta2;
+  theta8 = theta4 * theta4;
+  thetad = theta
+      * (1 + _k1 * theta2 + _k2 * theta4 + _k3 * theta6 + _k4 * theta8);
+
+  scaling = (r > 1e-8) ? thetad / r : 1.0;
+  y[0] *= scaling;
+  y[1] *= scaling;
+}
+
+template<typename DERIVED_Y, typename DERIVED_JY>
+void EquidistantDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & yconst,
+    const Eigen::MatrixBase<DERIVED_JY> & outJy) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+
+  //double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  Eigen::MatrixBase<DERIVED_JY> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JY> &>(outJy);
+  J.derived().resize(2, 2);
+  J.setZero();
+
+  Eigen::MatrixBase<DERIVED_Y> & y =
+      const_cast<Eigen::MatrixBase<DERIVED_Y> &>(yconst);
+  y.derived().resize(2);
+
+  double r, theta, theta2, theta4, theta6, theta8, thetad, scaling;
+
+  //MATLAB generated Jacobian
+  J(0, 0) = atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1])
+      * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+          + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+          + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+          + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0)
+      + y[0] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+          / sqrt(y[0] * y[0] + y[1] * y[1])
+          * ((_k2 * y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 3.0) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 4.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0)
+              + (_k3 * y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 5.0)
+                  * 1.0 / sqrt(y[0] * y[0] + y[1] * y[1]) * 6.0)
+                  / (y[0] * y[0] + y[1] * y[1] + 1.0)
+              + (_k4 * y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 7.0)
+                  * 1.0 / sqrt(y[0] * y[0] + y[1] * y[1]) * 8.0)
+                  / (y[0] * y[0] + y[1] * y[1] + 1.0)
+              + (_k1 * y[0] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+                  / sqrt(y[0] * y[0] + y[1] * y[1]) * 2.0)
+                  / (y[0] * y[0] + y[1] * y[1] + 1.0))
+      + ((y[0] * y[0])
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0))
+          / ((y[0] * y[0] + y[1] * y[1]) * (y[0] * y[0] + y[1] * y[1] + 1.0))
+      - (y[0] * y[0]) * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+          / pow(y[0] * y[0] + y[1] * y[1], 3.0 / 2.0)
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0);
+  J(0, 1) = y[0] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1])
+      * ((_k2 * y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 3.0) * 1.0
+          / sqrt(y[0] * y[0] + y[1] * y[1]) * 4.0)
+          / (y[0] * y[0] + y[1] * y[1] + 1.0)
+          + (_k3 * y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 5.0) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 6.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0)
+          + (_k4 * y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 7.0) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 8.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0)
+          + (_k1 * y[1] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 2.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0))
+      + (y[0] * y[1]
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0))
+          / ((y[0] * y[0] + y[1] * y[1]) * (y[0] * y[0] + y[1] * y[1] + 1.0))
+      - y[0] * y[1] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+          / pow(y[0] * y[0] + y[1] * y[1], 3.0 / 2.0)
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0);
+  J(1, 0) = y[1] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1])
+      * ((_k2 * y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 3.0) * 1.0
+          / sqrt(y[0] * y[0] + y[1] * y[1]) * 4.0)
+          / (y[0] * y[0] + y[1] * y[1] + 1.0)
+          + (_k3 * y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 5.0) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 6.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0)
+          + (_k4 * y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 7.0) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 8.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0)
+          + (_k1 * y[0] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 2.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0))
+      + (y[0] * y[1]
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0))
+          / ((y[0] * y[0] + y[1] * y[1]) * (y[0] * y[0] + y[1] * y[1] + 1.0))
+      - y[0] * y[1] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+          / pow(y[0] * y[0] + y[1] * y[1], 3.0 / 2.0)
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0);
+  J(1, 1) = atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1])
+      * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+          + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+          + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+          + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0)
+      + y[1] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+          / sqrt(y[0] * y[0] + y[1] * y[1])
+          * ((_k2 * y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 3.0) * 1.0
+              / sqrt(y[0] * y[0] + y[1] * y[1]) * 4.0)
+              / (y[0] * y[0] + y[1] * y[1] + 1.0)
+              + (_k3 * y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 5.0)
+                  * 1.0 / sqrt(y[0] * y[0] + y[1] * y[1]) * 6.0)
+                  / (y[0] * y[0] + y[1] * y[1] + 1.0)
+              + (_k4 * y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 7.0)
+                  * 1.0 / sqrt(y[0] * y[0] + y[1] * y[1]) * 8.0)
+                  / (y[0] * y[0] + y[1] * y[1] + 1.0)
+              + (_k1 * y[1] * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+                  / sqrt(y[0] * y[0] + y[1] * y[1]) * 2.0)
+                  / (y[0] * y[0] + y[1] * y[1] + 1.0))
+      + ((y[1] * y[1])
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0))
+          / ((y[0] * y[0] + y[1] * y[1]) * (y[0] * y[0] + y[1] * y[1] + 1.0))
+      - (y[1] * y[1]) * atan(sqrt(y[0] * y[0] + y[1] * y[1])) * 1.0
+          / pow(y[0] * y[0] + y[1] * y[1], 3.0 / 2.0)
+          * (_k1 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 2.0)
+              + _k2 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 4.0)
+              + _k3 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 6.0)
+              + _k4 * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 8.0) + 1.0);
+
+  r = sqrt(y[0] * y[0] + y[1] * y[1]);
+  theta = atan(r);
+  theta2 = theta * theta;
+  theta4 = theta2 * theta2;
+  theta6 = theta4 * theta2;
+  theta8 = theta4 * theta4;
+  thetad = theta
+      * (1 + _k1 * theta2 + _k2 * theta4 + _k3 * theta6 + _k4 * theta8);
+
+  scaling = (r > 1e-8) ? thetad / r : 1.0;
+  y[0] *= scaling;
+  y[1] *= scaling;
+}
+
+template<typename DERIVED>
+void EquidistantDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & yconst) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+
+  Eigen::MatrixBase<DERIVED> & y =
+      const_cast<Eigen::MatrixBase<DERIVED> &>(yconst);
+  y.derived().resize(2);
+
+  double theta, theta2, theta4, theta6, theta8, thetad, scaling;
+
+  thetad = sqrt(y[0] * y[0] + y[1] * y[1]);
+  theta = thetad;  // initial guess
+  for (int i = 20; i > 0; i--) {
+    theta2 = theta * theta;
+    theta4 = theta2 * theta2;
+    theta6 = theta4 * theta2;
+    theta8 = theta4 * theta4;
+    theta = thetad
+        / (1 + _k1 * theta2 + _k2 * theta4 + _k3 * theta6 + _k4 * theta8);
+  }
+  scaling = tan(theta) / thetad;
+
+  y[0] *= scaling;
+  y[1] *= scaling;
+}
+
+template<typename DERIVED, typename DERIVED_JY>
+void EquidistantDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & yconst,
+    const Eigen::MatrixBase<DERIVED_JY> & outJy) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+
+  Eigen::MatrixBase<DERIVED> & y =
+      const_cast<Eigen::MatrixBase<DERIVED> &>(yconst);
+  y.derived().resize(2);
+
+  // we use f^-1 ' = ( f'(f^-1) ) '
+  // with f^-1 the undistortion
+  // and  f the distortion
+  undistort(y);  // first get the undistorted image
+
+  Eigen::Vector2d kp = y;
+  Eigen::Matrix2d Jd;
+  distort(kp, Jd);
+
+  // now y = f^-1(y0)
+  DERIVED_JY & J = const_cast<DERIVED_JY &>(outJy.derived());
+
+  J = Jd.inverse();
+
+}
+
+template<typename DERIVED_Y, typename DERIVED_JD>
+void EquidistantDistortion::distortParameterJacobian(
+    const Eigen::MatrixBase<DERIVED_Y> & y,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JD>, 2, 4);
+
+  Eigen::MatrixBase<DERIVED_JD> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+  J.derived().resize(2, 4);
+  J.setZero();
+
+  J(0, 0) = y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 3.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(0, 1) = y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 5.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(0, 2) = y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 7.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(0, 3) = y[0] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 9.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(1, 0) = y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 3.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(1, 1) = y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 5.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(1, 2) = y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 7.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+  J(1, 3) = y[1] * pow(atan(sqrt(y[0] * y[0] + y[1] * y[1])), 9.0) * 1.0
+      / sqrt(y[0] * y[0] + y[1] * y[1]);
+
+  /*
+   double y0 = imageY[0];
+   double y1 = imageY[1];
+   double r2 = y0*y0 + y1*y1;
+   double r4 = r2*r2;
+
+   Eigen::MatrixBase<DERIVED_JD> & J = const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+   J.derived().resize(2,4);
+   J.setZero();
+
+   J(0,0) = y0*r2;
+   J(0,1) = y0*r4;
+   J(0,2) = 2.0*y0*y1;
+   J(0,3) = r2 + 2.0*y0*y0;
+
+   J(1,0) = y1*r2;
+   J(1,1) = y1*r4;
+   J(1,2) = r2 + 2.0*y1*y1;
+   J(1,3) = 2.0*y0*y1;
+   */
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/FovDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/FovDistortion.hpp
@@ -1,0 +1,175 @@
+#include "sm/assert_macros.hpp"
+
+namespace aslam {
+namespace cameras {
+
+template<typename DERIVED_Y>
+void FovDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & yconst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+
+  Eigen::MatrixBase<DERIVED_Y> & y =
+      const_cast<Eigen::MatrixBase<DERIVED_Y> &>(yconst);
+  y.derived().resize(2);
+
+  Eigen::Matrix2d J;
+  distort(y, J);
+}
+
+template<typename DERIVED_Y, typename DERIVED_JY>
+void FovDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & yconst,
+    const Eigen::MatrixBase<DERIVED_JY> & outJy) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+
+  Eigen::MatrixBase<DERIVED_JY> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JY> &>(outJy);
+  J.derived().resize(2, 2);
+  J.setZero();
+
+  Eigen::MatrixBase<DERIVED_Y> & y =
+      const_cast<Eigen::MatrixBase<DERIVED_Y> &>(yconst);
+  y.derived().resize(2);
+
+  const double r_u = y.norm();
+  const double r_u_cubed = r_u * r_u * r_u;
+  const double tanwhalf = tan(_w / 2.);
+  const double tanwhalfsq = tanwhalf * tanwhalf;
+  const double atan_wrd = atan(2. * tanwhalf * r_u);
+  double r_rd;
+
+  if (_w * _w < 1e-5) {
+    // Limit _w > 0.
+    r_rd = 1.0;
+  } else {
+    if (r_u * r_u < 1e-5) {
+      // Limit r_u > 0.
+      r_rd = 2. * tanwhalf / _w;
+    } else {
+      r_rd = atan_wrd / (r_u * _w);
+    }
+  }
+
+  const double& u = y(0);
+  const double& v = y(1);
+
+  if (_w * _w < 1e-5) {
+    J.setIdentity();
+  } else if (r_u * r_u < 1e-5) {
+    J.setIdentity();
+    // The coordinates get multiplied by an expression not depending on r_u.
+    J *= (2. * tanwhalf / _w);
+  } else {
+    const double duf_du = (atan_wrd) / (_w * r_u)
+              - (u * u * atan_wrd) / (_w * r_u_cubed)
+              + (2 * u * u * tanwhalf)
+              / (_w * (u * u + v * v) * (4 * tanwhalfsq * (u * u + v * v) + 1));
+    const double duf_dv = (2 * u * v * tanwhalf)
+              / (_w * (u * u + v * v) * (4 * tanwhalfsq * (u * u + v * v) + 1))
+              - (u * v * atan_wrd) / (_w * r_u_cubed);
+    const double dvf_du = (2 * u * v * tanwhalf)
+              / (_w * (u * u + v * v) * (4 * tanwhalfsq * (u * u + v * v) + 1))
+              - (u * v * atan_wrd) / (_w * r_u_cubed);
+    const double dvf_dv = (atan_wrd) / (_w * r_u)
+              - (v * v * atan_wrd) / (_w * r_u_cubed)
+              + (2 * v * v * tanwhalf)
+              / (_w * (u * u + v * v) * (4 * tanwhalfsq * (u * u + v * v) + 1));
+
+    J << duf_du, duf_dv,
+         dvf_du, dvf_dv;
+  }
+
+  y *= r_rd;
+}
+
+template<typename DERIVED>
+void FovDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & yconst) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+
+  Eigen::MatrixBase<DERIVED> & y =
+      const_cast<Eigen::MatrixBase<DERIVED> &>(yconst);
+  y.derived().resize(2);
+
+  double mul2tanwby2 = tan(_w / 2.0) * 2.0;
+
+  // Calculate distance from point to center.
+  double r_d = y.norm();
+
+  if (mul2tanwby2 == 0 || r_d == 0) {
+    return;
+  }
+
+  // Calculate undistorted radius of point.
+  double r_u;
+  if (fabs(r_d * _w) <= kMaxValidAngle) {
+    r_u = tan(r_d * _w) / (r_d * mul2tanwby2);
+  } else {
+    return;
+  }
+
+  y *= r_u;
+}
+
+template<typename DERIVED, typename DERIVED_JY>
+void FovDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & /*yconst*/,
+    const Eigen::MatrixBase<DERIVED_JY> & /*outJy*/) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+
+  SM_ASSERT_TRUE(std::runtime_error, false, "Not implemented.");
+}
+
+template<typename DERIVED_Y, typename DERIVED_JD>
+void FovDistortion::distortParameterJacobian(
+    const Eigen::MatrixBase<DERIVED_Y> & y,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JD>, 2, 4);
+
+  Eigen::MatrixBase<DERIVED_JD> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+  J.derived().resize(2, 1);
+  J.setZero();
+
+  const double tanwhalf = tan(_w / 2.);
+  const double tanwhalfsq = tanwhalf * tanwhalf;
+  const double r_u = y.norm();
+  const double atan_wrd = atan(2. * tanwhalf * r_u);
+
+  const double& u = y(0);
+  const double& v = y(1);
+
+  if (_w * _w < 1e-5) {
+    J.setZero();
+  }
+  else if (r_u * r_u < 1e-5) {
+    J.setOnes();
+    J *= (_w - sin(_w)) / (_w * _w * cos(_w / 2) * cos(_w / 2));
+  } else {
+    const double dxd_d_w = (2 * u * (tanwhalfsq / 2 + 0.5))
+          / (_w * (4 * tanwhalfsq * r_u * r_u + 1))
+          - (u * atan_wrd) / (_w * _w * r_u);
+
+    const double dyd_d_w = (2 * v * (tanwhalfsq / 2 + 0.5))
+          / (_w * (4 * tanwhalfsq * r_u * r_u + 1))
+          - (v * atan_wrd) / (_w * _w * r_u);
+
+    J << dxd_d_w, dyd_d_w;
+  }
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/NoDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/NoDistortion.hpp
@@ -1,0 +1,58 @@
+namespace aslam {
+namespace cameras {
+
+template<typename DERIVED_Y>
+void NoDistortion::distort(const Eigen::MatrixBase<DERIVED_Y> & /* y */) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+}
+
+template<typename DERIVED_Y, typename DERIVED_JY>
+void NoDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & /* y */,
+    const Eigen::MatrixBase<DERIVED_JY> & outJyConst) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+  Eigen::MatrixBase<DERIVED_JY> & outJy = const_cast<Eigen::MatrixBase<
+      DERIVED_JY> &>(outJyConst);
+  outJy.derived().resize(2, 2);
+  outJy.setIdentity();
+}
+
+template<typename DERIVED>
+void NoDistortion::undistort(const Eigen::MatrixBase<DERIVED> & /* y */) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+}
+
+template<typename DERIVED, typename DERIVED_JY>
+void NoDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & /* y */,
+    const Eigen::MatrixBase<DERIVED_JY> & outJyConst) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+  Eigen::MatrixBase<DERIVED_JY> & outJy = const_cast<Eigen::MatrixBase<
+      DERIVED_JY> &>(outJyConst);
+  outJy.derived().resize(2, 2);
+  outJy.setIdentity();
+}
+
+template<typename DERIVED_Y, typename DERIVED_JD>
+void NoDistortion::distortParameterJacobian(
+    const Eigen::MatrixBase<DERIVED_Y> & /* imageY */,
+    const Eigen::MatrixBase<DERIVED_JD> & outJdConst) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  // EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(Eigen::MatrixBase<DERIVED_JD>, 2, 2);
+  Eigen::MatrixBase<DERIVED_JD> & outJd = const_cast<Eigen::MatrixBase<
+      DERIVED_JD> &>(outJdConst);
+  outJd.derived().resize(2, 0);
+  //outJd.setIdentity();
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/OmniProjection.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/OmniProjection.hpp
@@ -1,0 +1,660 @@
+namespace aslam {
+
+namespace cameras {
+
+template<typename DISTORTION_T>
+OmniProjection<DISTORTION_T>::OmniProjection()
+    : _xi(0.0),
+      _fu(0.0),
+      _fv(0.0),
+      _cu(0.0),
+      _cv(0.0),
+      _ru(1),
+      _rv(1) {
+  updateTemporaries();
+
+}
+
+template<typename DISTORTION_T>
+OmniProjection<DISTORTION_T>::OmniProjection(double xi, double focalLengthU,
+                                             double focalLengthV,
+                                             double imageCenterU,
+                                             double imageCenterV,
+                                             int resolutionU, int resolutionV,
+                                             distortion_t distortion)
+    : _xi(xi),
+      _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _distortion(distortion) {
+  // 0
+  updateTemporaries();
+
+}
+
+template<typename DISTORTION_T>
+OmniProjection<DISTORTION_T>::OmniProjection(double xi, double focalLengthU,
+                                             double focalLengthV,
+                                             double imageCenterU,
+                                             double imageCenterV,
+                                             int resolutionU, int resolutionV)
+    : _xi(xi),
+      _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV) {
+  updateTemporaries();
+}
+
+template<typename DISTORTION_T>
+OmniProjection<DISTORTION_T>::~OmniProjection() {
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K>
+bool OmniProjection<DISTORTION_T>::euclideanToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypointConst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  Eigen::MatrixBase<DERIVED_K> & outKeypoint = const_cast<Eigen::MatrixBase<
+      DERIVED_K> &>(outKeypointConst);
+  outKeypoint.derived().resize(2);
+  //    SM_OUT(p.transpose());
+  double d = p.norm();
+
+  // Check if point will lead to a valid projection
+  if (p[2] <= -(_fov_parameter * d))
+    return false;
+
+  double rz = 1.0 / (p[2] + _xi * d);
+  outKeypoint[0] = p[0] * rz;
+  outKeypoint[1] = p[1] * rz;
+  //std::cout << "normalize\n";
+  //SM_OUT(d);
+  //SM_OUT(rz);
+  //SM_OUT(outKeypoint[0]);
+  //SM_OUT(outKeypoint[1]);
+
+  _distortion.distort(outKeypoint);
+  //std::cout << "distort\n";
+  //SM_OUT(outKeypoint[0]);
+  //SM_OUT(outKeypoint[1]);
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+  //std::cout << "project\n";
+  //SM_OUT(outKeypoint[0]);
+  //SM_OUT(outKeypoint[1]);
+
+  // Check if keypoint lies on the sensor
+  return isValid(outKeypoint);
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+bool OmniProjection<DISTORTION_T>::euclideanToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypointConst,
+    const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JP>, 2, 3);
+
+  Eigen::MatrixBase<DERIVED_K> & outKeypoint = const_cast<Eigen::MatrixBase<
+      DERIVED_K> &>(outKeypointConst);
+  outKeypoint.derived().resize(2);
+
+  // Jacobian:
+  Eigen::MatrixBase<DERIVED_JP> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JP> &>(outJp);
+  J.derived().resize(KeypointDimension, 3);
+  J.setZero();
+
+  double d = p.norm();
+
+  // Check if point will lead to a valid projection
+  if (p[2] <= -(_fov_parameter * d))
+    return false;
+
+  // project the point
+  double rz = 1.0 / (p[2] + _xi * d);
+  outKeypoint[0] = p[0] * rz;
+  outKeypoint[1] = p[1] * rz;
+
+  // Calculate jacobian
+  rz = rz * rz / d;
+  J(0, 0) = rz * (d * p[2] + _xi * (p[1] * p[1] + p[2] * p[2]));
+  J(1, 0) = -rz * _xi * p[0] * p[1];
+  J(0, 1) = J(1, 0);
+  J(1, 1) = rz * (d * p[2] + _xi * (p[0] * p[0] + p[2] * p[2]));
+  rz = rz * (-_xi * p[2] - d);
+  J(0, 2) = p[0] * rz;
+  J(1, 2) = p[1] * rz;
+
+  Eigen::Matrix2d Jd;
+  _distortion.distort(outKeypoint, Jd);
+
+  rz = _fu * (J(0, 0) * Jd(0, 0) + J(1, 0) * Jd(0, 1));
+  J(1, 0) = _fv * (J(0, 0) * Jd(1, 0) + J(1, 0) * Jd(1, 1));
+  J(0, 0) = rz;
+
+  rz = _fu * (J(0, 1) * Jd(0, 0) + J(1, 1) * Jd(0, 1));
+  J(1, 1) = _fv * (J(0, 1) * Jd(1, 0) + J(1, 1) * Jd(1, 1));
+  J(0, 1) = rz;
+
+  rz = _fu * (J(0, 2) * Jd(0, 0) + J(1, 2) * Jd(0, 1));
+  J(1, 2) = _fv * (J(0, 2) * Jd(1, 0) + J(1, 2) * Jd(1, 1));
+  J(0, 2) = rz;
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+
+  return isValid(outKeypoint);
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K>
+bool OmniProjection<DISTORTION_T>::homogeneousToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & ph,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  // hope this works... (required to have valid static asserts)
+  if (ph[3] < 0)
+    return euclideanToKeypoint(-ph.derived().template head<3>(), outKeypoint);
+  else
+    return euclideanToKeypoint(ph.derived().template head<3>(), outKeypoint);
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+bool OmniProjection<DISTORTION_T>::homogeneousToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & ph,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+    const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JP>, 2, 4);
+
+  Eigen::MatrixBase<DERIVED_JP> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JP> &>(outJp);
+  J.derived().resize(KeypointDimension, 4);
+  J.setZero();
+
+  if (ph[3] < 0) {
+    bool success = euclideanToKeypoint(
+        -ph.derived().template head<3>(), outKeypoint,
+        J.derived().template topLeftCorner<2, 3>());
+    J = -J;
+    return success;
+  } else {
+    return euclideanToKeypoint(ph.derived().template head<3>(), outKeypoint,
+                               J.derived().template topLeftCorner<2, 3>());
+  }
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P>
+bool OmniProjection<DISTORTION_T>::keypointToEuclidean(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPointConst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  Eigen::MatrixBase<DERIVED_P> & outPoint = const_cast<Eigen::MatrixBase<
+      DERIVED_P> &>(outPointConst);
+  outPoint.derived().resize(3);
+
+  // Unproject...
+  outPoint[0] = _recip_fu * (keypoint[0] - _cu);
+  outPoint[1] = _recip_fv * (keypoint[1] - _cv);
+
+  // Re-distort
+  _distortion.undistort(outPoint.derived().template head<2>());
+
+  double rho2_d = outPoint[0] * outPoint[0] + outPoint[1] * outPoint[1];
+
+  if (!isUndistortedKeypointValid(rho2_d))
+    return false;
+
+  outPoint[2] = 1
+      - _xi * (rho2_d + 1) / (_xi + sqrt(1 + (1 - _xi * _xi) * rho2_d));
+
+  return true;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+bool OmniProjection<DISTORTION_T>::keypointToEuclidean(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPointConst,
+    const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JK>, 3, 2);
+
+  Eigen::MatrixBase<DERIVED_P> & outPoint = const_cast<Eigen::MatrixBase<
+      DERIVED_P> &>(outPointConst);
+  outPoint.derived().resize(3);
+
+  // Unproject...
+  outPoint[0] = _recip_fu * (keypoint[0] - _cu);
+  outPoint[1] = _recip_fv * (keypoint[1] - _cv);
+
+  // Re-distort
+  Eigen::MatrixXd Jd(2, 2);
+  _distortion.undistort(outPoint.derived().template head<2>(), Jd);
+
+  double rho2_d = outPoint[0] * outPoint[0] + outPoint[1] * outPoint[1];
+
+  if (!isUndistortedKeypointValid(rho2_d))
+    return false;
+
+  double tmpZ = sqrt(-(rho2_d) * (_xi * _xi - 1.0) + 1.0);
+  double tmpA = _xi + tmpZ;
+  double recip_tmpA = 1.0 / tmpA;
+
+  outPoint[2] = 1 - _xi * (rho2_d + 1) * recip_tmpA;
+
+  // \todo analytical Jacobian
+  Eigen::MatrixBase<DERIVED_JK> & mbJk =
+      const_cast<Eigen::MatrixBase<DERIVED_JK> &>(outJk);
+  DERIVED_JK & Jk = mbJk.derived();
+
+  double r0 = outPoint[0];
+  double r1 = outPoint[1];
+
+  double recip_tmpA2 = recip_tmpA * recip_tmpA;
+  //double recip_tmpA2 = 1.0/tmpA2;
+  double tmpB = 1.0 / tmpZ;
+  Jk(0, 0) = Jd(0, 0) * _recip_fu;
+  Jk(0, 1) = Jd(0, 1) * _recip_fv;
+  Jk(1, 0) = Jd(1, 0) * _recip_fu;
+  Jk(1, 1) = Jd(1, 1) * _recip_fv;
+
+  double mul = -_xi
+      * (2.0 * recip_tmpA
+          + recip_tmpA2 * (_xi * _xi - 1.0) * tmpB * (rho2_d + 1.0));
+  Eigen::Vector2d J3;
+  J3[0] = r0 * mul;
+  J3[1] = r1 * mul;
+
+  Jk.row(2) = J3.transpose() * Jd
+      * Eigen::Vector2d(_recip_fu, _recip_fv).asDiagonal();
+
+  //ASLAM_CAMERAS_ESTIMATE_JACOBIAN(this,keypointToEuclidean, keypoint, 1e-5, Jk);
+
+  return true;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P>
+bool OmniProjection<DISTORTION_T>::keypointToHomogeneous(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPoint) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  Eigen::MatrixBase<DERIVED_P> & p =
+      const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPoint);
+  p.derived().resize(4);
+  p[3] = 0.0;
+  return keypointToEuclidean(keypoint, p.derived().template head<3>());
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+bool OmniProjection<DISTORTION_T>::keypointToHomogeneous(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPoint,
+    const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JK>, 4, 2);
+
+  Eigen::MatrixBase<DERIVED_JK> & Jk =
+      const_cast<Eigen::MatrixBase<DERIVED_JK> &>(outJk);
+  Jk.derived().resize(4, 2);
+  Jk.setZero();
+
+  Eigen::MatrixBase<DERIVED_P> & p =
+      const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPoint);
+  p.derived().resize(4);
+  p[3] = 0.0;
+
+  return keypointToEuclidean(keypoint, p.template head<3>(),
+                             Jk.template topLeftCorner<3, 2>());
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JI>
+void OmniProjection<DISTORTION_T>::euclideanToKeypointIntrinsicsJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JI>, (int) KeypointDimension, 5);
+
+  Eigen::MatrixBase<DERIVED_JI> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JI> &>(outJi);
+  J.derived().resize(KeypointDimension, 5);
+  J.setZero();
+
+  keypoint_t kp;
+  double d = p.norm();
+  double rz = 1.0 / (p[2] + _xi * d);
+  kp[0] = p[0] * rz;
+  kp[1] = p[1] * rz;
+
+  Eigen::Vector2d Jxi;
+  Jxi[0] = -kp[0] * d * rz;
+  Jxi[1] = -kp[1] * d * rz;
+
+  Eigen::Matrix2d Jd;
+  _distortion.distort(kp, Jd);
+
+  Jd.row(0) *= _fu;
+  Jd.row(1) *= _fv;
+  J.col(0) = Jd * Jxi;
+
+  J(0, 1) = kp[0];
+  J(0, 3) = 1;
+
+  J(1, 2) = kp[1];
+  J(1, 4) = 1;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JD>
+void OmniProjection<DISTORTION_T>::euclideanToKeypointDistortionJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+
+  double d = p.norm();
+  double rz = 1.0 / (p[2] + _xi * d);
+  keypoint_t kp;
+  kp[0] = p[0] * rz;
+  kp[1] = p[1] * rz;
+
+  _distortion.distortParameterJacobian(kp, outJd);
+
+  Eigen::MatrixBase<DERIVED_JD> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+
+  J.row(0) *= _fu;
+  J.row(1) *= _fv;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JI>
+void OmniProjection<DISTORTION_T>::homogeneousToKeypointIntrinsicsJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+
+  if (p[3] < 0.0) {
+    euclideanToKeypointIntrinsicsJacobian(-p.derived().template head<3>(),
+                                          outJi);
+  } else {
+    euclideanToKeypointIntrinsicsJacobian(p.derived().template head<3>(),
+                                          outJi);
+  }
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JD>
+void OmniProjection<DISTORTION_T>::homogeneousToKeypointDistortionJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+
+  if (p[3] < 0.0) {
+    euclideanToKeypointDistortionJacobian(-p.derived().template head<3>(),
+                                          outJd);
+  } else {
+    euclideanToKeypointDistortionJacobian(p.derived().template head<3>(),
+                                          outJd);
+  }
+
+}
+
+// \brief creates a random valid keypoint.
+template<typename DISTORTION_T>
+Eigen::VectorXd OmniProjection<DISTORTION_T>::createRandomKeypoint() const {
+
+  // This is tricky...The camera model defines a circle on the normalized image
+  // plane and the projection equations don't work outside of it.
+  // With some manipulation, we can see that, on the normalized image plane,
+  // the edge of this circle is at u^2 + v^2 = 1/(xi^2 - 1)
+  // So: this function creates keypoints inside this boundary.
+
+  // Create a point on the normalized image plane inside the boundary.
+  // This is not efficient, but it should be correct.
+
+  Eigen::Vector2d u(_ru + 1, _rv + 1);
+
+  while (u[0] <= 0 || u[0] >= _ru - 1 || u[1] <= 0 || u[1] >= _rv - 1) {
+    u.setRandom();
+    u = u - Eigen::Vector2d(0.5, 0.5);
+    u /= u.norm();
+    u *= ((double) rand() / (double) RAND_MAX) * _one_over_xixi_m_1;
+
+    // Now we run the point through distortion and projection.
+    // Apply distortion
+    _distortion.distort(u);
+
+    u[0] = _fu * u[0] + _cu;
+    u[1] = _fv * u[1] + _cv;
+  }
+
+  return u;
+}
+
+// \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+template<typename DISTORTION_T>
+Eigen::Vector3d OmniProjection<DISTORTION_T>::createRandomVisiblePoint(
+    double depth) const {
+  Eigen::VectorXd y = createRandomKeypoint();
+  Eigen::Vector3d p;
+  keypointToEuclidean(y, p);
+
+  if (depth < 0.0) {
+    depth = ((double) rand() / (double) RAND_MAX) * 100.0;
+  }
+
+  p /= p.norm();
+
+  // Muck with the depth. This doesn't change the pointing direction.
+  p *= depth;
+  return p;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K>
+bool OmniProjection<DISTORTION_T>::isValid(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  return keypoint(0) >= 0 && keypoint(0) < ru() && keypoint(1) >= 0
+      && keypoint(1) < rv();
+}
+
+template<typename DISTORTION_T>
+bool OmniProjection<DISTORTION_T>::isUndistortedKeypointValid(
+    const double rho2_d) const {
+  return xi() <= 1.0 || rho2_d <= _one_over_xixi_m_1;
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K>
+bool OmniProjection<DISTORTION_T>::isLiftable(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  // Unproject...
+  Eigen::Vector2d y;
+  y[0] = _recip_fu * (keypoint[0] - _cu);
+  y[1] = _recip_fv * (keypoint[1] - _cv);
+
+  // Re-distort
+  _distortion.undistort(y);
+
+  // Now check if it is on the sensor
+  double rho2_d = y[0] * y[0] + y[1] * y[1];
+  return isUndistortedKeypointValid(rho2_d);
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P>
+bool OmniProjection<DISTORTION_T>::isEuclideanVisible(
+    const Eigen::MatrixBase<DERIVED_P> & p) const {
+  keypoint_t k;
+  return euclideanToKeypoint(p, k);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P>
+bool OmniProjection<DISTORTION_T>::isHomogeneousVisible(
+    const Eigen::MatrixBase<DERIVED_P> & ph) const {
+  keypoint_t k;
+  return homogeneousToKeypoint(ph, k);
+}
+
+template<typename DISTORTION_T>
+void OmniProjection<DISTORTION_T>::updateTemporaries() {
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+  _one_over_xixi_m_1 = 1.0 / (_xi * _xi - 1);
+  _fov_parameter = (_xi <= 1.0) ? _xi : 1 / _xi;
+}
+
+// aslam::backend compatibility
+template<typename DISTORTION_T>
+void OmniProjection<DISTORTION_T>::update(const double * v) {
+  _xi += v[0];
+  _fu += v[1];
+  _fv += v[2];
+  _cu += v[3];
+  _cv += v[4];
+
+  updateTemporaries();
+
+}
+template<typename DISTORTION_T>
+int OmniProjection<DISTORTION_T>::minimalDimensions() const {
+  return 5;
+}
+
+template<typename DISTORTION_T>
+Eigen::Vector2i OmniProjection<DISTORTION_T>::parameterSize() const {
+  return Eigen::Vector2i(5, 1);
+}
+
+template<typename DISTORTION_T>
+void OmniProjection<DISTORTION_T>::getParameters(Eigen::MatrixXd & P) const {
+  P.resize(5, 1);
+  P << _xi, _fu, _fv, _cu, _cv;
+}
+template<typename DISTORTION_T>
+void OmniProjection<DISTORTION_T>::setParameters(const Eigen::MatrixXd & P) {
+  SM_ASSERT_EQ(std::runtime_error, P.rows(), 5, "Incorrect size");
+  SM_ASSERT_EQ(std::runtime_error, P.cols(), 1, "Incorrect size");
+  _xi = P(0, 0);
+  _fu = P(1, 0);
+  _fv = P(2, 0);
+  _cu = P(3, 0);
+  _cv = P(4, 0);
+
+  updateTemporaries();
+}
+
+template<typename DISTORTION_T>
+OmniProjection<DISTORTION_T> OmniProjection<DISTORTION_T>::getTestProjection() {
+  return OmniProjection<DISTORTION_T>(0.9, 400, 400, 320, 240, 640, 480,
+                                      DISTORTION_T::getTestDistortion());
+}
+
+template<typename DISTORTION_T>
+void OmniProjection<DISTORTION_T>::resizeIntrinsics(double scale) {
+  _fu *= scale;
+  _fv *= scale;
+  _cu *= scale;
+  _cv *= scale;
+  _ru = _ru * scale;
+  _rv = _rv * scale;
+
+  updateTemporaries();
+}
+
+namespace detail {
+
+inline double square(double x) {
+  return x * x;
+}
+inline float square(float x) {
+  return x * x;
+}
+inline double hypot(double a, double b) {
+  return sqrt(square(a) + square(b));
+}
+
+}  // namespace detail
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -1,0 +1,655 @@
+#include <opencv2/core/eigen.hpp>
+#include <Eigen/StdVector>
+
+#include "sm/assert_macros.hpp"
+#include "aslam/cameras/StaticAssert.hpp"
+
+namespace aslam {
+
+namespace cameras {
+
+template<typename DISTORTION_T>
+PinholeProjection<DISTORTION_T>::PinholeProjection()
+    : _fu(0.0),
+      _fv(0.0),
+      _cu(0.0),
+      _cv(0.0),
+      _ru(0),
+      _rv(0) {
+  updateTemporaries();
+}
+
+template<typename DISTORTION_T>
+PinholeProjection<DISTORTION_T>::PinholeProjection(double focalLengthU,
+                                                   double focalLengthV,
+                                                   double imageCenterU,
+                                                   double imageCenterV,
+                                                   int resolutionU,
+                                                   int resolutionV,
+                                                   distortion_t distortion)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _distortion(distortion) {
+  updateTemporaries();
+}
+
+template<typename DISTORTION_T>
+PinholeProjection<DISTORTION_T>::PinholeProjection(double focalLengthU,
+                                                   double focalLengthV,
+                                                   double imageCenterU,
+                                                   double imageCenterV,
+                                                   int resolutionU,
+                                                   int resolutionV)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV) {
+  updateTemporaries();
+}
+
+template<typename DISTORTION_T>
+PinholeProjection<DISTORTION_T>::~PinholeProjection() {
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K>
+bool PinholeProjection<DISTORTION_T>::euclideanToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypointConst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  Eigen::MatrixBase<DERIVED_K> & outKeypoint = const_cast<Eigen::MatrixBase<
+      DERIVED_K> &>(outKeypointConst);
+
+  outKeypoint.derived().resize(2);
+  double rz = 1.0 / p[2];
+  outKeypoint[0] = p[0] * rz;
+  outKeypoint[1] = p[1] * rz;
+
+  _distortion.distort(outKeypoint);
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+
+  return isValid(outKeypoint) && p[2] > 0;
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+bool PinholeProjection<DISTORTION_T>::euclideanToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypointConst,
+    const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JP>, 2, 3);
+
+  Eigen::MatrixBase<DERIVED_K> & outKeypoint = const_cast<Eigen::MatrixBase<
+      DERIVED_K> &>(outKeypointConst);
+  outKeypoint.derived().resize(2);
+
+  // Jacobian:
+  Eigen::MatrixBase<DERIVED_JP> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JP> &>(outJp);
+  J.derived().resize(KeypointDimension, 3);
+  J.setZero();
+
+  double rz = 1.0 / p[2];
+  double rz2 = rz * rz;
+
+  outKeypoint[0] = p[0] * rz;
+  outKeypoint[1] = p[1] * rz;
+
+  Eigen::MatrixXd Jd;
+  _distortion.distort(outKeypoint, Jd);  // distort and Jacobian wrt. keypoint
+
+  // Jacobian including distortion
+  J(0, 0) = _fu * Jd(0, 0) * rz;
+  J(0, 1) = _fu * Jd(0, 1) * rz;
+  J(0, 2) = -_fu * (p[0] * Jd(0, 0) + p[1] * Jd(0, 1)) * rz2;
+  J(1, 0) = _fv * Jd(1, 0) * rz;
+  J(1, 1) = _fv * Jd(1, 1) * rz;
+  J(1, 2) = -_fv * (p[0] * Jd(1, 0) + p[1] * Jd(1, 1)) * rz2;
+
+  outKeypoint[0] = _fu * outKeypoint[0] + _cu;
+  outKeypoint[1] = _fv * outKeypoint[1] + _cv;
+
+  return isValid(outKeypoint) && p[2] > 0;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K>
+bool PinholeProjection<DISTORTION_T>::homogeneousToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & ph,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypoint) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  // hope this works... (required to have valid static asserts)
+  if (ph[3] < 0)
+    return euclideanToKeypoint(-ph.derived().template head<3>(), outKeypoint);
+  else
+    return euclideanToKeypoint(ph.derived().template head<3>(), outKeypoint);
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_K, typename DERIVED_JP>
+bool PinholeProjection<DISTORTION_T>::homogeneousToKeypoint(
+    const Eigen::MatrixBase<DERIVED_P> & ph,
+    const Eigen::MatrixBase<DERIVED_K> & outKeypoint,
+    const Eigen::MatrixBase<DERIVED_JP> & outJp) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JP>, 2, 4);
+
+  Eigen::MatrixBase<DERIVED_JP> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JP> &>(outJp);
+  J.derived().resize(KeypointDimension, 4);
+  J.setZero();
+
+  // hope this works... (required to have valid static asserts)
+  return euclideanToKeypoint(ph.derived().template head<3>(), outKeypoint,
+                             J.derived().template topLeftCorner<2, 3>());
+
+  if (ph[3] < 0) {
+    bool success = euclideanToKeypoint(
+        -ph.derived().template head<3>(), outKeypoint,
+        J.derived().template topLeftCorner<2, 3>());
+    J = -J;
+    return success;
+  } else {
+    return euclideanToKeypoint(ph.derived().template head<3>(), outKeypoint,
+                               J.derived().template topLeftCorner<2, 3>());
+  }
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P>
+bool PinholeProjection<DISTORTION_T>::keypointToEuclidean(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPointConst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  keypoint_t kp = keypoint;
+
+  kp[0] = (kp[0] - _cu) / _fu;
+  kp[1] = (kp[1] - _cv) / _fv;
+  _distortion.undistort(kp);  // revert distortion
+
+  Eigen::MatrixBase<DERIVED_P> & outPoint = const_cast<Eigen::MatrixBase<
+      DERIVED_P> &>(outPointConst);
+  outPoint.derived().resize(3);
+
+  outPoint[0] = kp[0];
+  outPoint[1] = kp[1];
+  outPoint[2] = 1;
+
+  return isValid(keypoint);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+bool PinholeProjection<DISTORTION_T>::keypointToEuclidean(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPointConst,
+    const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JK>, 3, 2);
+
+  keypoint_t kp = keypoint;
+
+  kp[0] = (kp[0] - _cu) / _fu;
+  kp[1] = (kp[1] - _cv) / _fv;
+
+  Eigen::MatrixXd Jd(2, 2);
+
+  _distortion.undistort(kp, Jd);  // revert distortion
+
+  Eigen::MatrixBase<DERIVED_P> & outPoint = const_cast<Eigen::MatrixBase<
+      DERIVED_P> &>(outPointConst);
+  outPoint.derived().resize(3);
+
+  outPoint[0] = kp[0];
+  outPoint[1] = kp[1];
+  outPoint[2] = 1;
+
+  Eigen::MatrixBase<DERIVED_JK> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JK> &>(outJk);
+  J.derived().resize(3, KeypointDimension);
+  J.setZero();
+
+  //J.derived()(0,0) = 1.0;
+  //J.derived()(1,1) = _fu_over_fv;
+
+  J.derived()(0, 0) = _recip_fu;
+  J.derived()(1, 1) = _recip_fv;
+
+  J *= Jd;
+
+  return isValid(keypoint);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P>
+bool PinholeProjection<DISTORTION_T>::keypointToHomogeneous(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPoint) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+
+  Eigen::MatrixBase<DERIVED_P> & p =
+      const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPoint);
+  p.derived().resize(4);
+  p[3] = 0.0;
+  return keypointToEuclidean(keypoint, p.derived().template head<3>());
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K, typename DERIVED_P, typename DERIVED_JK>
+bool PinholeProjection<DISTORTION_T>::keypointToHomogeneous(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint,
+    const Eigen::MatrixBase<DERIVED_P> & outPoint,
+    const Eigen::MatrixBase<DERIVED_JK> & outJk) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_K>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JK>, 4, 2);
+
+  Eigen::MatrixBase<DERIVED_JK> & Jk = const_cast<Eigen::MatrixBase<DERIVED_JK> &>(outJk);
+
+  Jk.derived().resize(4, 2);
+  Jk.setZero();
+
+  Eigen::MatrixBase<DERIVED_P> & p =
+      const_cast<Eigen::MatrixBase<DERIVED_P> &>(outPoint);
+  p[3] = 0.0;
+
+  return keypointToEuclidean(keypoint, p.template head<3>(),
+                             Jk.template topLeftCorner<3, 2>());
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JI>
+void PinholeProjection<DISTORTION_T>::euclideanToKeypointIntrinsicsJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JI>, 2, 4);
+
+  Eigen::MatrixBase<DERIVED_JI> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JI> &>(outJi);
+  J.derived().resize(KeypointDimension, 4);
+  J.setZero();
+
+  double rz = 1.0 / p[2];
+
+  keypoint_t kp;
+  kp[0] = p[0] * rz;
+  kp[1] = p[1] * rz;
+  _distortion.distort(kp);
+
+  J(0, 0) = kp[0];
+  J(0, 2) = 1;
+
+  J(1, 1) = kp[1];
+  J(1, 3) = 1;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JD>
+void PinholeProjection<DISTORTION_T>::euclideanToKeypointDistortionJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 3);
+
+  double rz = 1.0 / p[2];
+  keypoint_t kp;
+  kp[0] = p[0] * rz;
+  kp[1] = p[1] * rz;
+
+  _distortion.distortParameterJacobian(kp, outJd);
+
+  Eigen::MatrixBase<DERIVED_JD> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+  J.derived().resize(KeypointDimension, _distortion.minimalDimensions());
+
+  J.row(0) *= _fu;
+  J.row(1) *= _fv;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JI>
+void PinholeProjection<DISTORTION_T>::homogeneousToKeypointIntrinsicsJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JI> & outJi) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JI>, 2, 4);
+
+  if (p[3] < 0.0) {
+    euclideanToKeypointIntrinsicsJacobian(-p.derived().template head<3>(),
+                                          outJi);
+  } else {
+    euclideanToKeypointIntrinsicsJacobian(p.derived().template head<3>(),
+                                          outJi);
+  }
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P, typename DERIVED_JD>
+void PinholeProjection<DISTORTION_T>::homogeneousToKeypointDistortionJacobian(
+    const Eigen::MatrixBase<DERIVED_P> & p,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_P>, 4);
+
+  if (p[3] < 0.0) {
+    euclideanToKeypointDistortionJacobian(-p.derived().template head<3>(),
+                                          outJd);
+  } else {
+    euclideanToKeypointDistortionJacobian(p.derived().template head<3>(),
+                                          outJd);
+  }
+
+}
+
+// \brief creates a random valid keypoint.
+template<typename DISTORTION_T>
+Eigen::VectorXd PinholeProjection<DISTORTION_T>::createRandomKeypoint() const {
+  Eigen::VectorXd out(2, 1);
+  out.setRandom();
+  out(0) = fabs(out(0)) * _ru;
+  out(1) = fabs(out(1)) * _rv;
+  return out;
+}
+
+// \brief creates a random visible point. Negative depth means random between 0 and 100 meters.
+template<typename DISTORTION_T>
+Eigen::Vector3d PinholeProjection<DISTORTION_T>::createRandomVisiblePoint(
+    double depth) const {
+  Eigen::VectorXd y = createRandomKeypoint();
+  Eigen::Vector3d p;
+  keypointToEuclidean(y, p);
+
+  if (depth < 0.0) {
+    depth = ((double) rand() / (double) RAND_MAX) * 100.0;
+  }
+
+  p /= p.norm();
+
+  // Muck with the depth. This doesn't change the pointing direction.
+  p *= depth;
+  return p;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_K>
+bool PinholeProjection<DISTORTION_T>::isValid(
+    const Eigen::MatrixBase<DERIVED_K> & keypoint) const {
+  return keypoint[0] >= 0 && keypoint[1] >= 0 && keypoint[0] < (double) _ru
+      && keypoint[1] < (double) _rv;
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P>
+bool PinholeProjection<DISTORTION_T>::isEuclideanVisible(
+    const Eigen::MatrixBase<DERIVED_P> & p) const {
+  keypoint_t k;
+  return euclideanToKeypoint(p, k);
+
+}
+
+template<typename DISTORTION_T>
+template<typename DERIVED_P>
+bool PinholeProjection<DISTORTION_T>::isHomogeneousVisible(
+    const Eigen::MatrixBase<DERIVED_P> & ph) const {
+  keypoint_t k;
+  return homogeneousToKeypoint(ph, k);
+}
+
+template<typename DISTORTION_T>
+void PinholeProjection<DISTORTION_T>::update(const double * v) {
+  _fu += v[0];
+  _fv += v[1];
+  _cu += v[2];
+  _cv += v[3];
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+}
+
+template<typename DISTORTION_T>
+int PinholeProjection<DISTORTION_T>::minimalDimensions() const {
+  return IntrinsicsDimension;
+}
+
+template<typename DISTORTION_T>
+void PinholeProjection<DISTORTION_T>::getParameters(Eigen::MatrixXd & P) const {
+  P.resize(4, 1);
+  P(0, 0) = _fu;
+  P(1, 0) = _fv;
+  P(2, 0) = _cu;
+  P(3, 0) = _cv;
+}
+
+template<typename DISTORTION_T>
+void PinholeProjection<DISTORTION_T>::setParameters(const Eigen::MatrixXd & P) {
+  _fu = P(0, 0);
+  _fv = P(1, 0);
+  _cu = P(2, 0);
+  _cv = P(3, 0);
+  updateTemporaries();
+}
+
+template<typename DISTORTION_T>
+Eigen::Vector2i PinholeProjection<DISTORTION_T>::parameterSize() const {
+  return Eigen::Vector2i(4, 1);
+}
+
+template<typename DISTORTION_T>
+void PinholeProjection<DISTORTION_T>::updateTemporaries() {
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+
+}
+
+template<typename DISTORTION_T>
+PinholeProjection<DISTORTION_T> PinholeProjection<DISTORTION_T>::getTestProjection() {
+  return PinholeProjection<DISTORTION_T>(400, 400, 320, 240, 640, 480,
+                                         DISTORTION_T::getTestDistortion());
+}
+
+template<typename DISTORTION_T>
+void PinholeProjection<DISTORTION_T>::resizeIntrinsics(double scale) {
+  _fu *= scale;
+  _fv *= scale;
+  _cu *= scale;
+  _cv *= scale;
+  _ru = _ru * scale;
+  _rv = _rv * scale;
+
+  updateTemporaries();
+}
+
+/// \brief Get a set of border rays
+template<typename DISTORTION_T>
+void PinholeProjection<DISTORTION_T>::getBorderRays(Eigen::MatrixXd & rays) {
+  rays.resize(4, 8);
+  keypointToHomogeneous(Eigen::Vector2d(0.0, 0.0), rays.col(0));
+  keypointToHomogeneous(Eigen::Vector2d(0.0, _rv * 0.5), rays.col(1));
+  keypointToHomogeneous(Eigen::Vector2d(0.0, _rv - 1.0), rays.col(2));
+  keypointToHomogeneous(Eigen::Vector2d(_ru - 1.0, 0.0), rays.col(3));
+  keypointToHomogeneous(Eigen::Vector2d(_ru - 1.0, _rv * 0.5), rays.col(4));
+  keypointToHomogeneous(Eigen::Vector2d(_ru - 1.0, _rv - 1.0), rays.col(5));
+  keypointToHomogeneous(Eigen::Vector2d(_ru * 0.5, 0.0), rays.col(6));
+  keypointToHomogeneous(Eigen::Vector2d(_ru * 0.5, _rv - 1.0), rays.col(7));
+
+}
+
+class PinholeHelpers {
+public:
+
+  static inline double square(double x) {
+    return x*x;
+  }
+  static inline float square(float x) {
+    return x*x;
+  }
+  static inline double hypot(double a, double b) {
+    return sqrt(square(a) + square(b));
+  }
+
+  static std::vector<cv::Point2d> intersectCircles(double x1, double y1, double r1,
+                                            double x2, double y2, double r2) {
+    std::vector<cv::Point2d> ipts;
+
+    double d = hypot(x1-x2, y1-y2);
+    if (d > r1 + r2) {
+      // circles are separate
+      return ipts;
+    }
+    if (d < fabs(r1 - r2)) {
+      // one circle is contained within the other
+      return ipts;
+    }
+
+    double a = (square(r1) - square(r2) + square(d)) / (2.0 * d);
+    double h = sqrt(square(r1) - square(a));
+
+    double x3 = x1 + a * (x2 - x1) / d;
+    double y3 = y1 + a * (y2 - y1) / d;
+
+    if (h < 1e-10) {
+      // two circles touch at one point
+      ipts.push_back(cv::Point2d(x3, y3));
+      return ipts;
+    }
+
+    ipts.push_back(cv::Point2d(x3 + h * (y2 - y1) / d, y3 - h * (x2 - x1) / d));
+    ipts.push_back(cv::Point2d(x3 - h * (y2 - y1) / d, y3 + h * (x2 - x1) / d));
+    return ipts;
+  }
+
+  static void fitCircle(const std::vector<cv::Point2d>& points, double& centerX,
+                 double& centerY, double& radius) {
+    // D. Umbach, and K. Jones, A Few Methods for Fitting Circles to Data,
+    // IEEE Transactions on Instrumentation and Measurement, 2000
+    // We use the modified least squares method.
+    double sum_x = 0.0;
+    double sum_y = 0.0;
+    double sum_xx = 0.0;
+    double sum_xy = 0.0;
+    double sum_yy = 0.0;
+    double sum_xxx = 0.0;
+    double sum_xxy = 0.0;
+    double sum_xyy = 0.0;
+    double sum_yyy = 0.0;
+
+    int n = points.size();
+    for (int i = 0; i < n; ++i) {
+      double x = points.at(i).x;
+      double y = points.at(i).y;
+
+      sum_x += x;
+      sum_y += y;
+      sum_xx += x * x;
+      sum_xy += x * y;
+      sum_yy += y * y;
+      sum_xxx += x * x * x;
+      sum_xxy += x * x * y;
+      sum_xyy += x * y * y;
+      sum_yyy += y * y * y;
+    }
+
+    double A = n * sum_xx - square(sum_x);
+    double B = n * sum_xy - sum_x * sum_y;
+    double C = n * sum_yy - square(sum_y);
+    double D = 0.5
+        * (n * sum_xyy - sum_x * sum_yy + n * sum_xxx - sum_x * sum_xx);
+    double E = 0.5
+        * (n * sum_xxy - sum_y * sum_xx + n * sum_yyy - sum_y * sum_yy);
+
+    centerX = (D * C - B * E) / (A * C - square(B));
+    centerY = (A * E - B * D) / (A * C - square(B));
+
+    double sum_r = 0.0;
+    for (int i = 0; i < n; ++i) {
+      double x = points.at(i).x;
+      double y = points.at(i).y;
+      sum_r += hypot(x - centerX, y - centerY);
+    }
+    radius = sum_r / n;
+  }
+
+  static double medianOfVectorElements(std::vector<double> values)
+  {
+    double median;
+    size_t size = values.size();
+    std::sort(values.begin(), values.end());
+    if (size%2 == 0)
+        median = (values[size / 2 - 1] + values[size / 2]) / 2;
+    else
+        median = values[size / 2];
+    return median;
+  }
+
+}; // class PinholeHelpers
+
+
+}  // namespace cameras
+
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/implementation/RadialTangentialDistortion.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/implementation/RadialTangentialDistortion.hpp
@@ -1,0 +1,185 @@
+namespace aslam {
+namespace cameras {
+
+template<typename DERIVED_Y>
+void RadialTangentialDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & yconst) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+
+  Eigen::MatrixBase<DERIVED_Y> & y =
+      const_cast<Eigen::MatrixBase<DERIVED_Y> &>(yconst);
+  y.derived().resize(2);
+
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = y[0] * y[0];
+  my2_u = y[1] * y[1];
+  mxy_u = y[0] * y[1];
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  y[0] += y[0] * rad_dist_u + 2.0 * _p1 * mxy_u + _p2 * (rho2_u + 2.0 * mx2_u);
+  y[1] += y[1] * rad_dist_u + 2.0 * _p2 * mxy_u + _p1 * (rho2_u + 2.0 * my2_u);
+
+}
+
+template<typename DERIVED_Y, typename DERIVED_JY>
+void RadialTangentialDistortion::distort(
+    const Eigen::MatrixBase<DERIVED_Y> & yconst,
+    const Eigen::MatrixBase<DERIVED_JY> & outJy) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  Eigen::MatrixBase<DERIVED_JY> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JY> &>(outJy);
+  J.derived().resize(2, 2);
+  J.setZero();
+
+  Eigen::MatrixBase<DERIVED_Y> & y =
+      const_cast<Eigen::MatrixBase<DERIVED_Y> &>(yconst);
+  y.derived().resize(2);
+
+  mx2_u = y[0] * y[0];
+  my2_u = y[1] * y[1];
+  mxy_u = y[0] * y[1];
+  rho2_u = mx2_u + my2_u;
+
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+
+  J(0, 0) = 1 + rad_dist_u + _k1 * 2.0 * mx2_u + _k2 * rho2_u * 4 * mx2_u
+      + 2.0 * _p1 * y[1] + 6 * _p2 * y[0];
+  J(1, 0) = _k1 * 2.0 * y[0] * y[1] + _k2 * 4 * rho2_u * y[0] * y[1]
+      + _p1 * 2.0 * y[0] + 2.0 * _p2 * y[1];
+  J(0, 1) = J(1, 0);
+  J(1, 1) = 1 + rad_dist_u + _k1 * 2.0 * my2_u + _k2 * rho2_u * 4 * my2_u
+      + 6 * _p1 * y[1] + 2.0 * _p2 * y[0];
+
+  y[0] += y[0] * rad_dist_u + 2.0 * _p1 * mxy_u + _p2 * (rho2_u + 2.0 * mx2_u);
+  y[1] += y[1] * rad_dist_u + 2.0 * _p2 * mxy_u + _p1 * (rho2_u + 2.0 * my2_u);
+
+}
+
+template<typename DERIVED>
+void RadialTangentialDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & yconst) const {
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+
+  Eigen::MatrixBase<DERIVED> & y =
+      const_cast<Eigen::MatrixBase<DERIVED> &>(yconst);
+  y.derived().resize(2);
+
+  Eigen::Vector2d ybar = y;
+  const int n = 5;
+  Eigen::Matrix2d F;
+
+  Eigen::Vector2d y_tmp;
+
+  for (int i = 0; i < n; i++) {
+
+    y_tmp = ybar;
+
+    distort(y_tmp, F);
+
+    Eigen::Vector2d e(y - y_tmp);
+    Eigen::Vector2d du = (F.transpose() * F).inverse() * F.transpose() * e;
+
+    ybar += du;
+
+    if (e.dot(e) < 1e-15)
+      break;
+
+  }
+  y = ybar;
+
+}
+
+template<typename DERIVED, typename DERIVED_JY>
+void RadialTangentialDistortion::undistort(
+    const Eigen::MatrixBase<DERIVED> & yconst,
+    const Eigen::MatrixBase<DERIVED_JY> & outJy) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JY>, 2, 2);
+
+  Eigen::MatrixBase<DERIVED> & y =
+      const_cast<Eigen::MatrixBase<DERIVED> &>(yconst);
+  y.derived().resize(2);
+
+  // we use f^-1 ' = ( f'(f^-1) ) '
+  // with f^-1 the undistortion
+  // and  f the distortion
+  undistort(y);  // first get the undistorted image
+
+  Eigen::Vector2d kp = y;
+  Eigen::Matrix2d Jd;
+  distort(kp, Jd);
+
+  // now y = f^-1(y0)
+  DERIVED_JY & J = const_cast<DERIVED_JY &>(outJy.derived());
+
+  J = Jd.inverse();
+
+  /*  std::cout << "J: " << std::endl << J << std::endl;
+
+   double mx2_u = y[0]*y[0];
+   double my2_u = y[1]*y[1];
+   //double mxy_u = y[0]*y[1];
+   double rho2_u = mx2_u+my2_u;
+
+   double rad_dist_u = _k1*rho2_u+_k2*rho2_u*rho2_u;
+   // take the inverse as Jacobian.
+   J(0,0) = 1/(1 + rad_dist_u + _k1*2*mx2_u + _k2*rho2_u*4*mx2_u + 2*_p1*y[1] + 6*_p2*y[0]);
+   J(1,0) = (_k1*2*y[0]*y[1] + _k2*4*rho2_u*y[0]*y[1] + _p1*2*y[0] + 2*_p2*y[1]);
+   J(0,1) = J(1,0);
+   J(1,1) = 1/(1 + rad_dist_u + _k1*2*my2_u + _k2*rho2_u*4*my2_u + 6*_p1*y[1] + 2*_p2*y[0]);
+
+   // this should only happen if the distortion coefficients are 0
+   // the coefficients being zero removes the cross dependence then it is safe to set J(1,0) = 0
+   if (J(1,0) != 0)
+   J(1,0) = 1/J(1,0);
+   J(0,1) = J(1,0);*/
+
+}
+
+template<typename DERIVED_Y, typename DERIVED_JD>
+void RadialTangentialDistortion::distortParameterJacobian(
+    const Eigen::MatrixBase<DERIVED_Y> & imageY,
+    const Eigen::MatrixBase<DERIVED_JD> & outJd) const {
+
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_Y>, 2);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE_OR_DYNAMIC(
+      Eigen::MatrixBase<DERIVED_JD>, 2, 4);
+
+  double y0 = imageY[0];
+  double y1 = imageY[1];
+  double r2 = y0 * y0 + y1 * y1;
+  double r4 = r2 * r2;
+
+  Eigen::MatrixBase<DERIVED_JD> & J =
+      const_cast<Eigen::MatrixBase<DERIVED_JD> &>(outJd);
+  J.derived().resize(2, 4);
+  J.setZero();
+
+  J(0, 0) = y0 * r2;
+  J(0, 1) = y0 * r4;
+  J(0, 2) = 2.0 * y0 * y1;
+  J(0, 3) = r2 + 2.0 * y0 * y0;
+
+  J(1, 0) = y1 * r2;
+  J(1, 1) = y1 * r4;
+  J(1, 2) = r2 + 2.0 * y1 * y1;
+  J(1, 3) = 2.0 * y0 * y1;
+
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/include/aslam/cameras/test/CameraGeometryTestHarness.hpp
+++ b/deps/aslam_cameras/include/aslam/cameras/test/CameraGeometryTestHarness.hpp
@@ -1,0 +1,381 @@
+// Bring in gtest
+#include <gtest/gtest.h>
+#include <boost/lexical_cast.hpp>
+
+namespace aslam {
+namespace cameras {
+
+// Helpers adapted from sm_kinematics
+inline Eigen::Vector3d fromHomogeneous(const Eigen::Vector4d & v) {
+    double rv3 = 1.0 / v[3];
+    return v.head<3>() * rv3;
+}
+
+inline Eigen::Vector4d toHomogeneous(const Eigen::Vector3d & v)
+{
+    return Eigen::Vector4d(v[0],v[1],v[2],1.0);
+}
+
+// Helper from sm/string_routines
+template<typename T, typename U, typename V>
+inline std::string s_tuple(T t, U u, V v)
+{
+    std::ostringstream s;
+    s << "[" << t << "," << u << "," << v << "]";
+    return s.str();
+}
+
+template<typename CAMERA_GEOMETRY_T>
+class CameraGeometryTestHarness {
+ public:
+  typedef CAMERA_GEOMETRY_T camera_geometry_t;
+  typedef typename camera_geometry_t::keypoint_t keypoint_t;
+  typedef typename camera_geometry_t::jacobian_homogeneous_t jacobian_homogeneous_t;
+  typedef typename camera_geometry_t::jacobian_t jacobian_t;
+  typedef typename camera_geometry_t::inverse_jacobian_t inverse_jacobian_t;
+  typedef typename camera_geometry_t::inverse_jacobian_homogeneous_t inverse_jacobian_homogeneous_t;
+  typedef typename camera_geometry_t::projection_t::jacobian_intrinsics_t jacobian_intrinsics_t;
+  typedef Eigen::Vector3d point_t;
+  typedef Eigen::Vector4d pointh_t;
+  typedef typename camera_geometry_t::projection_t projection_t;
+
+  camera_geometry_t _geometry;
+  double _tolerance;
+
+  CameraGeometryTestHarness()
+      : _tolerance(1e-2) {
+    _geometry = camera_geometry_t::getTestGeometry();
+  }
+
+  CameraGeometryTestHarness(const camera_geometry_t & geometry,
+                            double tolerance)
+      : _geometry(geometry),
+        _tolerance(tolerance) {
+  }
+
+  CameraGeometryTestHarness(const camera_geometry_t & geometry)
+      : _geometry(geometry),
+        _tolerance(1e-2) {
+  }
+
+  CameraGeometryTestHarness(double tolerance)
+      : _tolerance(tolerance) {
+    _geometry = camera_geometry_t::getTestGeometry();
+  }
+
+  virtual ~CameraGeometryTestHarness() {
+  }
+
+  void testKeypointToEuclidean() {
+    SCOPED_TRACE(__FUNCTION__);
+
+    for (int i = 0; i < 20; i++) {
+
+      keypoint_t y = _geometry.createRandomKeypoint();
+      // Test that we can go from a keypoint to Euclidean and back to within tolerance.
+      inverse_jacobian_t J;
+      point_t p;
+      _geometry.keypointToEuclidean(y, p, J);
+
+      sm::eigen::assertFinite(p, SM_SOURCE_FILE_POS);
+      sm::eigen::assertFinite(J, SM_SOURCE_FILE_POS);
+
+      keypoint_t yhat;
+      _geometry.euclideanToKeypoint(p, yhat);
+
+      sm::eigen::assertFinite(yhat, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat, _tolerance, "");
+
+      pointh_t ph = toHomogeneous(p);
+      keypoint_t yhat2;
+      _geometry.homogeneousToKeypoint(ph, yhat2);
+      sm::eigen::assertFinite(yhat2, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat2, _tolerance, "");
+
+      ph = -ph;
+      _geometry.homogeneousToKeypoint(ph, yhat2);
+      sm::eigen::assertFinite(yhat2, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat2, _tolerance, "");
+
+      inverse_jacobian_t Jest;
+      _geometry.keypointToEuclideanFiniteDifference(y, p, Jest);
+      ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+    }
+
+  }
+
+  void testKeypointToHomogeneous() {
+    SCOPED_TRACE(__FUNCTION__);
+    for (int i = 0; i < 20; i++) {
+      point_t p = _geometry.createRandomVisiblePoint();
+      pointh_t ph = toHomogeneous(p);
+      keypoint_t y;
+      _geometry.euclideanToKeypoint(p, y);
+      // Test that we can go from a keypoint to Euclidean and back to within tolerance.
+      inverse_jacobian_homogeneous_t J;
+      pointh_t ph2;
+      _geometry.keypointToHomogeneous(y, ph2, J);
+
+      sm::eigen::assertFinite(ph, SM_SOURCE_FILE_POS);
+      sm::eigen::assertFinite(J, SM_SOURCE_FILE_POS);
+
+      keypoint_t yhat;
+      _geometry.homogeneousToKeypoint(ph, yhat);
+      sm::eigen::assertFinite(yhat, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat, _tolerance, "");
+
+      // point_t p = fromHomogeneous(ph);
+      // keypoint_t yhat2;
+      // _geometry.euclideanToKeypoint(p,yhat2);
+      // sm::eigen::assertFinite(yhat2,SM_SOURCE_FILE_POS);
+      // ASSERT_DOUBLE_MX_EQ(y,yhat2,_tolerance,"");
+
+      inverse_jacobian_homogeneous_t Jest;
+      //std::cout << ph.transpose() << "\n";
+      _geometry.keypointToHomogeneousFiniteDifference(y, ph2, Jest);
+      ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+      ph = -ph;
+      _geometry.homogeneousToKeypoint(ph, yhat);
+      sm::eigen::assertFinite(yhat, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat, _tolerance, "");
+
+    }
+  }
+
+  void testEuclideanToKeypoint() {
+    SCOPED_TRACE(__FUNCTION__);
+    for (int i = 0; i < 20; i++) {
+      keypoint_t y = _geometry.createRandomKeypoint();
+
+      jacobian_t J;
+      point_t p;
+      _geometry.keypointToEuclidean(y, p);
+      sm::eigen::assertFinite(p, SM_SOURCE_FILE_POS);
+
+      keypoint_t yhat;
+      _geometry.euclideanToKeypoint(p, yhat, J);
+      sm::eigen::assertFinite(yhat, SM_SOURCE_FILE_POS);
+      sm::eigen::assertFinite(J, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat, _tolerance, "");
+
+      pointh_t ph = toHomogeneous(p);
+      keypoint_t yhat2;
+      _geometry.homogeneousToKeypoint(ph, yhat2);
+      sm::eigen::assertFinite(yhat2, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat2, _tolerance, "");
+
+      ph = -ph;
+      _geometry.homogeneousToKeypoint(ph, yhat2);
+      sm::eigen::assertFinite(yhat2, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat2, _tolerance, "");
+
+      if (_geometry.isProjectionInvertible()) {
+        // If the sensor model is invertible, we should get the same point in space.
+        pointh_t ph2;
+        _geometry.keypointToHomogeneous(y, ph2);
+        point_t p2 = fromHomogeneous(ph2);
+        ASSERT_DOUBLE_MX_EQ(p, p2, _tolerance, "");
+      }
+
+      jacobian_t Jest;
+      _geometry.euclideanToKeypointFiniteDifference(p, yhat, Jest);
+      ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+
+    }
+  }
+
+  void testHomogeneousToKeypoint() {
+    SCOPED_TRACE(__FUNCTION__);
+    for (int i = 0; i < 20; i++) {
+      keypoint_t y = _geometry.createRandomKeypoint();
+
+      jacobian_homogeneous_t J;
+      pointh_t ph;
+      _geometry.keypointToHomogeneous(y, ph);
+
+      // having the fourth component be zero can be a singularity
+      // for the Jacobian of some camera models. 
+      // Setting this to 1.0 seems to work and is still testing what
+      // we want.
+      if (ph[3] == 0.0)
+        ph[3] = 1.0;
+      sm::eigen::assertFinite(ph, SM_SOURCE_FILE_POS);
+
+      keypoint_t yhat;
+      _geometry.homogeneousToKeypoint(ph, yhat, J);
+      sm::eigen::assertFinite(yhat, SM_SOURCE_FILE_POS);
+      sm::eigen::assertFinite(J, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat, _tolerance, "");
+      jacobian_homogeneous_t Jest;
+      _geometry.homogeneousToKeypointFiniteDifference(ph, y, Jest);
+      ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+
+      if (_geometry.isProjectionInvertible()) {
+        point_t pp = fromHomogeneous(ph);
+        keypoint_t yhat2;
+        _geometry.euclideanToKeypoint(pp, yhat2);
+        sm::eigen::assertFinite(yhat2, SM_SOURCE_FILE_POS);
+        ASSERT_DOUBLE_MX_EQ(y, yhat2, _tolerance, "");
+
+        // If the sensor model is invertible, we should get the same point in space.p
+        point_t p2;
+        _geometry.keypointToEuclidean(y, p2);
+        ASSERT_DOUBLE_MX_EQ(pp, p2, _tolerance, "");
+      }
+      // This should still work
+      ph = -ph;
+
+      _geometry.homogeneousToKeypoint(ph, yhat, J);
+      sm::eigen::assertFinite(yhat, SM_SOURCE_FILE_POS);
+      sm::eigen::assertFinite(J, SM_SOURCE_FILE_POS);
+      ASSERT_DOUBLE_MX_EQ(y, yhat, _tolerance, "");
+      _geometry.homogeneousToKeypointFiniteDifference(ph, y, Jest);
+      ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+
+    }
+  }
+
+  void testIntrinsicsJacobian() {
+    SCOPED_TRACE(__FUNCTION__);
+    if (_geometry.projection().minimalDimensions() > 0) {
+
+      for (int i = 0; i < 20; i++) {
+        point_t p = _geometry.createRandomVisiblePoint(2);
+
+        jacobian_intrinsics_t J;
+        _geometry.euclideanToKeypointIntrinsicsJacobian(p, J);
+
+        jacobian_intrinsics_t Jest;
+        _geometry.euclideanToKeypointIntrinsicsJacobianFiniteDifference(p,
+                                                                        Jest);
+        ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+
+        Eigen::Vector4d ph = toHomogeneous(p);
+        _geometry.homogeneousToKeypointIntrinsicsJacobian(ph, J);
+        _geometry.homogeneousToKeypointIntrinsicsJacobianFiniteDifference(ph,
+                                                                          Jest);
+        ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+
+        ph = -ph;
+        _geometry.homogeneousToKeypointIntrinsicsJacobian(ph, J);
+        _geometry.homogeneousToKeypointIntrinsicsJacobianFiniteDifference(ph,
+                                                                          Jest);
+        ASSERT_DOUBLE_MX_EQ(J, Jest, _tolerance, "");
+
+      }
+    }
+  }
+
+  void testDistortionJacobian() {
+    SCOPED_TRACE(__FUNCTION__);
+    if (_geometry.projection().distortion().minimalDimensions() > 0) {
+
+      // An initial test along the optical axis.
+      point_t p(0.0, 0.0, 10.0);
+      if (_geometry.isEuclideanVisible(p)) {
+        SCOPED_TRACE(" P: " + s_tuple(p(0), p(1), p(2)));
+        //std::cout << "Optical axis\n";
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> J;
+        _geometry.euclideanToKeypointDistortionJacobian(p, J);
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> Jest;
+
+        _geometry.euclideanToKeypointDistortionJacobianFiniteDifference(p,
+                                                                        Jest);
+        sm::eigen::assertNear(J, Jest, 1e-5, SM_SOURCE_FILE_POS,
+                              "Distortion Jacobian");
+        // This relative tolerance test was too strict for small values.
+        // ASSERT_DOUBLE_MX_EQ(J,Jest,_tolerance,"");
+      }
+
+      p << 0.0, 0.0, -10.0;
+      if (_geometry.isEuclideanVisible(p)) {
+        SCOPED_TRACE(" P: " + s_tuple(p(0), p(1), p(2)));
+        //std::cout << "Negative optical axis\n";
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> J;
+        _geometry.euclideanToKeypointDistortionJacobian(p, J);
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> Jest;
+
+        _geometry.euclideanToKeypointDistortionJacobianFiniteDifference(p,
+                                                                        Jest);
+        sm::eigen::assertNear(J, Jest, 1e-5, SM_SOURCE_FILE_POS,
+                              "Distortion Jacobian");
+        // This relative tolerance test was too strict for small values.
+        //ASSERT_DOUBLE_MX_EQ(J,Jest,_tolerance,"");
+      }
+
+      // For some reason this case is difficult for the omni camera
+      p << 1e-1, 1e-1, 10.0;
+      if (_geometry.isEuclideanVisible(p)) {
+        SCOPED_TRACE(" P: " + s_tuple(p(0), p(1), p(2)));
+        //std::cout << "Negative optical axis\n";
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> J;
+        _geometry.euclideanToKeypointDistortionJacobian(p, J);
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> Jest;
+
+        _geometry.euclideanToKeypointDistortionJacobianFiniteDifference(p,
+                                                                        Jest);
+        // This relative tolerance test was too strict for small values.
+        //ASSERT_DOUBLE_MX_EQ(J,Jest,_tolerance,"");
+        sm::eigen::assertNear(J, Jest, 1e-5, SM_SOURCE_FILE_POS,
+                              "Distortion Jacobian");
+      }
+
+      for (int i = 0; i < 200; i++) {
+        point_t p = _geometry.createRandomVisiblePoint(10);
+        SCOPED_TRACE(
+            "Trial " + boost::lexical_cast < std::string
+                > (i) + " P: " + s_tuple(p(0), p(1), p(2)));
+        // SM_OUT(p);
+        // keypoint_t k;
+        // bool valid = _geometry.euclideanToKeypoint(p,k);
+        // SM_OUT(k);
+        // SM_OUT(valid);
+
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> J;
+        _geometry.euclideanToKeypointDistortionJacobian(p, J);
+        Eigen::Matrix<double, 2, projection_t::distortion_t::IntrinsicsDimension> Jest;
+
+        _geometry.euclideanToKeypointDistortionJacobianFiniteDifference(p,
+                                                                        Jest);
+
+        // This relative tolerance test was too strict for small values.
+        //ASSERT_DOUBLE_MX_EQ(J,Jest,_tolerance,"");
+        sm::eigen::assertNear(J, Jest, 1e-5, SM_SOURCE_FILE_POS,
+                              "Distortion Jacobian");
+      }
+    }
+  }
+
+  void testAll() {
+    {
+      SCOPED_TRACE("EuclideanToKeypoint");
+      testEuclideanToKeypoint();
+    }
+    {
+      SCOPED_TRACE("HomogeneousToKeypoint");
+      testHomogeneousToKeypoint();
+    }
+
+    {
+      SCOPED_TRACE("KeypointToEuclidean");
+      testKeypointToEuclidean();
+    }
+    {
+      SCOPED_TRACE("KeypointToHomogeneous");
+      testKeypointToHomogeneous();
+    }
+    {
+      SCOPED_TRACE("IntrinsicsJacobian");
+      testIntrinsicsJacobian();
+    }
+    {
+      SCOPED_TRACE("DistortionJacobian");
+      testDistortionJacobian();
+    }
+  }
+
+};
+
+}  // namespace cameras
+}  // namespace asl
+

--- a/deps/aslam_cameras/include/sm/assert_macros.hpp
+++ b/deps/aslam_cameras/include/sm/assert_macros.hpp
@@ -1,0 +1,299 @@
+/**
+ * @file   assert_macros.hpp
+ * @author Paul Furgale <paul.furgale@gmail.com>
+ * @date   Mon Dec 12 11:22:20 2011
+ * 
+ * @brief  Assert macros to facilitate rapid prototyping. Use them early and often.
+ * 
+ * 
+ */
+
+#ifndef SM_ASSERT_HPP
+#define SM_ASSERT_HPP
+
+#include <stdexcept>
+#include <sstream>
+#include <typeinfo>
+#include "source_file_pos.hpp"
+
+//! Macro for defining an exception with a given parent
+//  (std::runtime_error should be top parent)
+// adapted from ros/drivers/laser/hokuyo_driver/hokuyo.h
+#define SM_DEFINE_EXCEPTION(exceptionName, exceptionParent)				\
+  class exceptionName : public exceptionParent {						\
+  public:																\
+  exceptionName(const char * message) : exceptionParent(message) {}		\
+  exceptionName(std::string const & message) : exceptionParent(message) {} \
+  virtual ~exceptionName() throw() {}									\
+  };									  
+
+namespace sm {
+
+  namespace detail {
+
+    template<typename SM_EXCEPTION_T>
+    inline void sm_throw_exception(std::string const & exceptionType, sm::source_file_pos sfp, std::string const & message)
+    {
+      std::stringstream sm_assert_stringstream;
+#ifdef _WIN32
+      // I have no idea what broke this on Windows but it doesn't work with the << operator.
+      sm_assert_stringstream << exceptionType <<  sfp.toString() << " " << message;
+#else
+      sm_assert_stringstream << exceptionType <<  sfp << " " << message;
+#endif
+      throw(SM_EXCEPTION_T(sm_assert_stringstream.str()));
+    }
+
+    template<typename SM_EXCEPTION_T>
+    inline void sm_throw_exception(std::string const & exceptionType, std::string const & function, std::string const & file,
+								   int line, std::string const & message)
+    {
+      sm_throw_exception<SM_EXCEPTION_T>(exceptionType, sm::source_file_pos(function,file,line),message);
+    }
+
+
+  } // namespace sm::detail
+
+  template<typename SM_EXCEPTION_T>
+  inline void sm_assert_throw(bool assert_condition, std::string message, sm::source_file_pos sfp) {
+    if(!assert_condition)
+      {
+		detail::sm_throw_exception<SM_EXCEPTION_T>("", sfp,message);
+      }
+  }
+
+
+
+} // namespace sm
+
+
+
+#define SM_THROW(exceptionType, message) {								\
+    std::stringstream sm_assert_stringstream;							\
+    sm_assert_stringstream << message;									\
+    sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+  }
+
+
+#define SM_THROW_SFP(exceptionType, SourceFilePos, message){			\
+    std::stringstream sm_assert_stringstream;							\
+    sm_assert_stringstream << message;									\
+    sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", SourceFilePos, sm_assert_stringstream.str()); \
+  }
+
+#define SM_ASSERT_TRUE(exceptionType, condition, message)				\
+  if(!(condition))														\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #condition << ") failed: " << message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_FALSE(exceptionType, condition, message)				\
+  if((condition))														\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert( not " << #condition << ") failed: " << message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_GE_LT(exceptionType, value, lowerBound, upperBound, message) \
+  if((value) < (lowerBound) || (value) >= (upperBound))							\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #lowerBound << " <= " << #value << " < " << #upperBound << ") failed [" << (lowerBound) << " <= " << (value) << " < " << (upperBound) << "]: " << message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_LT(exceptionType, value, upperBound, message)			\
+  if((value) >= (upperBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " < " << #upperBound << ") failed [" << (value) << " < " << (upperBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_GE(exceptionType, value, lowerBound, message)			\
+  if((value) < (lowerBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " >= " << #lowerBound << ") failed [" << (value) << " >= " << (lowerBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_LE(exceptionType, value, upperBound, message)			\
+  if((value) > (upperBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " <= " << #upperBound << ") failed [" << (value) << " <= " << (upperBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_GT(exceptionType, value, lowerBound, message)			\
+  if((value) <= (lowerBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " > " << #lowerBound << ") failed [" << (value) << " > " << (lowerBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_EQ(exceptionType, value, testValue, message)			\
+  if((value) != (testValue))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " == " << #testValue << ") failed [" << (value) << " == " << (testValue) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_NE(exceptionType, value, testValue, message)			\
+  if((value) == (testValue))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " != " << #testValue << ") failed [" << (value) << " != " << (testValue) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_NEAR(exceptionType, value, testValue, abs_error, message) \
+  if(!(fabs((testValue) - (value)) <= fabs(abs_error)))						\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "assert(" << #value << " == " << #testValue << ") failed [" << (value) << " == " << (testValue) << " (" << fabs((testValue) - (value)) << " > " << fabs(abs_error) << ")]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#ifndef NDEBUG
+
+#define SM_THROW_DBG(exceptionType, message){							\
+    std::stringstream sm_assert_stringstream;							\
+    sm_assert_stringstream << message;									\
+    sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+  }
+
+
+
+#define SM_ASSERT_TRUE_DBG(exceptionType, condition, message)			\
+  if(!(condition))														\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #condition << ") failed: " << message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_FALSE_DBG(exceptionType, condition, message)			\
+  if((condition))														\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert( not " << #condition << ") failed: " << message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+    }
+
+
+#define SM_ASSERT_DBG_RE( condition, message) SM_ASSERT_DBG(std::runtime_error, condition, message)
+
+#define SM_ASSERT_GE_LT_DBG(exceptionType, value, lowerBound, upperBound, message) \
+  if((value) < (lowerBound) || (value) >= (upperBound))							\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #lowerBound << " <= " << #value << " < " << #upperBound << ") failed [" << (lowerBound) << " <= " << (value) << " < " << (upperBound) << "]: " << message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_LT_DBG(exceptionType, value, upperBound, message)		\
+  if((value) >= (upperBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " < " << #upperBound << ") failed [" << (value) << " < " << (upperBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_GE_DBG(exceptionType, value, lowerBound, message)		\
+  if((value) < (lowerBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " >= " << #lowerBound << ") failed [" << (value) << " >= " << (lowerBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_LE_DBG(exceptionType, value, upperBound, message)		\
+  if((value) > (upperBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " <= " << #upperBound << ") failed [" << (value) << " <= " << (upperBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+#define SM_ASSERT_GT_DBG(exceptionType, value, lowerBound, message)		\
+  if((value) <= (lowerBound))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " > " << #lowerBound << ") failed [" << (value) << " > " << (lowerBound) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_EQ_DBG(exceptionType, value, testValue, message)		\
+  if((value) != (testValue))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " == " << #testValue << ") failed [" << (value) << " == " << (testValue) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+#define SM_ASSERT_NE_DBG(exceptionType, value, testValue, message)		\
+  if((value) == (testValue))												\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " != " << #testValue << ") failed [" << (value) << " != " << (testValue) << "]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+
+#define SM_ASSERT_NEAR_DBG(exceptionType, value, testValue, abs_error, message) \
+  if(!(fabs((testValue) - (value)) <= fabs(abs_error)))						\
+    {																	\
+      std::stringstream sm_assert_stringstream;							\
+      sm_assert_stringstream << "debug assert(" << #value << " == " << #testValue << ") failed [" << (value) << " == " << (testValue) << " (" << fabs((testValue) - (value)) << " > " << fabs(abs_error) << ")]: " <<  message; \
+      sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__,sm_assert_stringstream.str()); \
+    }
+
+
+#define SM_OUT(X) std::cout << #X << ": " << (X) << std::endl
+
+#else
+
+#define SM_OUT(X)
+#define SM_THROW_DBG(exceptionType, message)
+#define SM_ASSERT_TRUE_DBG(exceptionType, condition, message)
+#define SM_ASSERT_FALSE_DBG(exceptionType, condition, message)
+#define SM_ASSERT_GE_LT_DBG(exceptionType, value, lowerBound, upperBound, message)
+#define SM_ASSERT_LT_DBG(exceptionType, value, upperBound, message)
+#define SM_ASSERT_GT_DBG(exceptionType, value, lowerBound, message)
+#define SM_ASSERT_LE_DBG(exceptionType, value, upperBound, message)
+#define SM_ASSERT_GE_DBG(exceptionType, value, lowerBound, message)
+#define SM_ASSERT_NE_DBG(exceptionType, value, testValue, message)
+#define SM_ASSERT_EQ_DBG(exceptionType, value, testValue, message)
+#define SM_ASSERT_NEAR_DBG(exceptionType, value, testValue, abs_error, message)	
+#endif
+
+
+
+#endif

--- a/deps/aslam_cameras/include/sm/gtest.hpp
+++ b/deps/aslam_cameras/include/sm/gtest.hpp
@@ -1,0 +1,150 @@
+/**
+ * @file   gtest.hpp
+ * @author Paul Furgale <paul.furgale@gmail.com>
+ * @date   Mon Dec 12 11:54:20 2011
+ * 
+ * @brief  Code to simplify Eigen integration into GTest. Pretty basic but the error messages are good.
+ * 
+ * 
+ */
+#ifndef SM_EIGEN_GTEST_HPP
+#define SM_EIGEN_GTEST_HPP
+
+#include <gtest/gtest.h>
+#include <sm/source_file_pos.hpp>
+#include <Eigen/Core>
+
+namespace sm { namespace eigen {
+
+
+
+    template<int N>
+    Eigen::Matrix<double,N,N> randomCovariance()
+    {
+      Eigen::Matrix<double,N,N> U;
+      U.setRandom();
+      return U.transpose() * U + 5.0 * Eigen::Matrix<double,N,N>::Identity();
+    }
+
+
+    inline Eigen::MatrixXd randomCovarianceXd(int N)
+    {
+        Eigen::MatrixXd U(N,N);
+        U.setRandom();
+        return U.transpose() * U + 5.0 * Eigen::MatrixXd::Identity(N,N);
+    }
+
+
+
+    template<typename M1, typename M2>
+    void assertEqual(const M1 & A, const M2 & B, sm::source_file_pos const & sfp, std::string const & message = "")
+    {
+        ASSERT_EQ((size_t)A.rows(),(size_t)B.rows()) << message << "\nMatrix A:\n" << A << "\nand matrix B\n" << B << "\nare not the same\n" << sfp.toString();
+      ASSERT_EQ((size_t)A.cols(),(size_t)B.cols()) << message << "\nMatrix A:\n" << A << "\nand matrix B\n" << B << "\nare not the same\n" << sfp.toString();
+
+      for(int r = 0; r < A.rows(); r++)
+		{
+		  for(int c = 0; c < A.cols(); c++)
+			{
+			  ASSERT_EQ(A(r,c),B(r,c)) << message << "\nEquality comparison failed at (" << r << "," << c << ")\n" << sfp.toString()
+                                       << "\nMatrix A:\n" << A << "\nand matrix B\n" << B; 
+			}
+		}
+    }
+
+
+    template<typename M1, typename M2, typename T>
+    void assertNear(const M1 & A, const M2 & B, T tolerance, sm::source_file_pos const & sfp, std::string const & message = "")
+    {
+      // Note: If these assertions fail, they only abort this subroutine.
+      // see: http://code.google.com/p/googletest/wiki/AdvancedGuide#Using_Assertions_in_Sub-routines
+      // \todo better handling of this
+        ASSERT_EQ((size_t)A.rows(),(size_t)B.rows()) << message << "\nMatrix A:\n" << A << "\nand matrix B\n" << B << "\nare not the same\n" << sfp.toString();
+      ASSERT_EQ((size_t)A.cols(),(size_t)B.cols()) << message << "\nMatrix A:\n" << A << "\nand matrix B\n" << B << "\nare not the same\n" << sfp.toString();
+
+      for(int r = 0; r < A.rows(); r++)
+		{
+		  for(int c = 0; c < A.cols(); c++)
+			{
+			  ASSERT_NEAR(A(r,c),B(r,c),tolerance) << message << "\nTolerance comparison failed at (" << r << "," << c << ")\n" << sfp.toString()
+												   << "\nMatrix A:\n" << A << "\nand matrix B\n" << B; 
+			}
+		}
+    }
+
+    template<typename M1, typename M2, typename T>
+    void expectNear(const M1 & A, const M2 & B, T tolerance, sm::source_file_pos const & sfp, std::string const & message = "")
+    {
+      EXPECT_EQ((size_t)A.rows(),(size_t)B.rows()) << message << "\nMatrix A:\n" << A << "\nand matrix B\n" << B << "\nare not the same\n" << sfp.toString();
+      EXPECT_EQ((size_t)A.cols(),(size_t)B.cols()) << message << "\nMatrix A:\n" << A << "\nand matrix B\n" << B << "\nare not the same\n" << sfp.toString();
+
+      for(int r = 0; r < A.rows(); r++)
+        {
+          for(int c = 0; c < A.cols(); c++)
+            {
+              EXPECT_NEAR(A(r,c),B(r,c),tolerance) << message << "\nTolerance comparison failed at (" << r << "," << c << ")\n" << sfp.toString()
+												   << "\nMatrix A:\n" << A << "\nand matrix B\n" << B;
+            }
+        }
+    }
+
+
+    template<typename M1>
+    void assertFinite(const M1 & A, sm::source_file_pos const & sfp, std::string const & message = "")
+    {
+      for(int r = 0; r < A.rows(); r++)
+		{
+		  for(int c = 0; c < A.cols(); c++)
+			{
+			  ASSERT_TRUE(std::isfinite(A(r,c))) << sfp.toString() << std::endl << message << std::endl << "Check for finite values failed at A(" << r << "," << c << "). Matrix A:" << std::endl << A << std::endl;
+			}
+		}
+    }
+
+
+    
+    inline bool compareRelative(double a, double b, double percentTolerance, double * percentError = NULL)
+    {
+	  // \todo: does anyone have a better idea?
+      double fa = fabs(a);
+      double fb = fabs(b);
+      if( (fa < 1e-15 && fb < 1e-15) ||  // Both zero.
+		  (fa == 0.0  && fb < 1e-6)  ||  // One exactly zero and the other small
+		  (fb == 0.0  && fa < 1e-6) )    // ditto
+		return true;
+      
+      double diff = fabs(a - b)/std::max(fa,fb);
+      if(diff > percentTolerance * 1e-2)
+		{
+		  if(percentError)
+			*percentError = diff * 100.0;
+		  return false;
+		}
+      return true;
+    }
+
+    
+#define ASSERT_DOUBLE_MX_EQ(A, B, PERCENT_TOLERANCE, MSG)				\
+    ASSERT_EQ((size_t)(A).rows(), (size_t)(B).rows())  << MSG << "\nMatrix " << #A << ":\n" << A << "\nand matrix " << #B << "\n" << B << "\nare not the same size"; \
+    ASSERT_EQ((size_t)(A).cols(), (size_t)(B).cols())  << MSG << "\nMatrix " << #A << ":\n" << A << "\nand matrix " << #B << "\n" << B << "\nare not the same size"; \
+    for(int r = 0; r < (A).rows(); r++)									\
+      {																	\
+		for(int c = 0; c < (A).cols(); c++)								\
+		  {																\
+			double percentError = 0.0;									\
+			ASSERT_TRUE(sm::eigen::compareRelative( (A)(r,c), (B)(r,c), PERCENT_TOLERANCE, &percentError)) \
+			  << MSG << "\nComparing:\n"								\
+			  << #A << "(" << r << "," << c << ") = " << (A)(r,c) << std::endl \
+			  << #B << "(" << r << "," << c << ") = " << (B)(r,c) << std::endl \
+			  << "Error was " << percentError << "% > " << PERCENT_TOLERANCE << "%\n" \
+			  << "\nMatrix " << #A << ":\n" << A << "\nand matrix " << #B << "\n" << B; \
+		  }																\
+      }
+    
+    
+
+
+
+  }} // namespace sm::eigen
+
+#endif /* SM_EIGEN_GTEST_HPP */

--- a/deps/aslam_cameras/include/sm/source_file_pos.hpp
+++ b/deps/aslam_cameras/include/sm/source_file_pos.hpp
@@ -1,0 +1,47 @@
+#ifndef SM_SOURCE_FILE_POS_HPP
+#define SM_SOURCE_FILE_POS_HPP
+
+#include <string>
+#include <iostream>
+#include <sstream>
+// A class and macro that gives you the current file position.
+
+namespace sm {
+
+  class source_file_pos
+  {
+  public:
+    std::string function;
+    std::string file;
+    int line;
+
+    source_file_pos(std::string function, std::string file, int line) :
+      function(function), file(file), line(line) {}
+
+    operator std::string()
+    {
+      return toString();
+    }
+
+    std::string toString() const
+    {
+      std::stringstream s;
+      s << file << ":" << line << ": " << function << "()";
+      return s.str();
+    }
+
+  };
+
+}// namespace sm
+
+inline std::ostream & operator<<(std::ostream & out, const sm::source_file_pos & sfp)
+{
+  out << sfp.file << ":" << sfp.line << ": " << sfp.function << "()";
+  return out;
+}
+
+
+#define SM_SOURCE_FILE_POS sm::source_file_pos(__FUNCTION__,__FILE__,__LINE__)
+
+#endif
+

--- a/deps/aslam_cameras/src/CameraGeometryBase.cpp
+++ b/deps/aslam_cameras/src/CameraGeometryBase.cpp
@@ -1,0 +1,22 @@
+#include <aslam/cameras/CameraGeometryBase.hpp>
+#include <aslam/cameras.hpp>
+namespace aslam {
+namespace cameras {
+
+CameraGeometryBase::CameraGeometryBase() {
+}
+;
+CameraGeometryBase::~CameraGeometryBase() {
+}
+;
+
+bool CameraGeometryBase::hasMask() const
+{
+	SM_THROW(std::runtime_error, "not implemented!");
+	return false;
+}
+
+
+}  // namespace cameras
+}  // namespace aslam
+

--- a/deps/aslam_cameras/src/EquidistantDistortion.cpp
+++ b/deps/aslam_cameras/src/EquidistantDistortion.cpp
@@ -1,0 +1,70 @@
+#include <aslam/cameras/EquidistantDistortion.hpp>
+
+namespace aslam {
+namespace cameras {
+
+EquidistantDistortion::EquidistantDistortion()
+    : _k1(0),
+      _k2(0),
+      _k3(0),
+      _k4(0) {
+
+}
+
+EquidistantDistortion::EquidistantDistortion(double k1, double k2, double k3,
+                                             double k4)
+    : _k1(k1),
+      _k2(k2),
+      _k3(k3),
+      _k4(k4) {
+
+}
+
+EquidistantDistortion::~EquidistantDistortion() {
+
+}
+
+// aslam::backend compatibility
+void EquidistantDistortion::update(const double * v) {
+  _k1 += v[0];
+  _k2 += v[1];
+  _k3 += v[2];
+  _k4 += v[3];
+}
+
+int EquidistantDistortion::minimalDimensions() const {
+  return IntrinsicsDimension;
+}
+
+void EquidistantDistortion::getParameters(Eigen::MatrixXd & S) const {
+  S.resize(4, 1);
+  S(0, 0) = _k1;
+  S(1, 0) = _k2;
+  S(2, 0) = _k3;
+  S(3, 0) = _k4;
+}
+
+void EquidistantDistortion::setParameters(const Eigen::MatrixXd & S) {
+  _k1 = S(0, 0);
+  _k2 = S(1, 0);
+  _k3 = S(2, 0);
+  _k4 = S(3, 0);
+}
+
+Eigen::Vector2i EquidistantDistortion::parameterSize() const {
+  return Eigen::Vector2i(4, 1);
+}
+
+EquidistantDistortion EquidistantDistortion::getTestDistortion() {
+  return EquidistantDistortion(-0.2, 0.13, 0.0005, 0.0005);
+}
+
+void EquidistantDistortion::clear() {
+  _k1 = 0.0;
+  _k2 = 0.0;
+  _k3 = 0.0;
+  _k4 = 0.0;
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/FovDistortion.cpp
+++ b/deps/aslam_cameras/src/FovDistortion.cpp
@@ -1,0 +1,52 @@
+#include <aslam/cameras/FovDistortion.hpp>
+#include "sm/assert_macros.hpp"
+
+namespace aslam {
+namespace cameras {
+
+FovDistortion::FovDistortion()
+    : _w(1.0) {
+  SM_ASSERT_TRUE(std::runtime_error, areParametersValid(_w), "Invalid distortion parameter");
+}
+
+FovDistortion::FovDistortion(double w)
+    : _w(w){
+  SM_ASSERT_TRUE(std::runtime_error, areParametersValid(w), "Invalid distortion parameter");
+}
+
+FovDistortion::~FovDistortion() {}
+
+// aslam::backend compatibility
+void FovDistortion::update(const double * v) {
+  _w += v[0];
+  SM_ASSERT_TRUE(std::runtime_error, areParametersValid(_w), "Invalid distortion parameter");
+}
+
+int FovDistortion::minimalDimensions() const {
+  return IntrinsicsDimension;
+}
+
+void FovDistortion::getParameters(Eigen::MatrixXd & S) const {
+  S.resize(1, 1);
+  S(0, 0) = _w;
+}
+
+void FovDistortion::setParameters(const Eigen::MatrixXd & S) {
+  _w = S(0, 0);
+  SM_ASSERT_TRUE(std::runtime_error, areParametersValid(_w), "Invalid distortion parameter");
+}
+
+Eigen::Vector2i FovDistortion::parameterSize() const {
+  return Eigen::Vector2i(1, 1);
+}
+
+FovDistortion FovDistortion::getTestDistortion() {
+  return FovDistortion(1.0);
+}
+
+void FovDistortion::clear() {
+  _w = 1.0;
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/GlobalShutter.cpp
+++ b/deps/aslam_cameras/src/GlobalShutter.cpp
@@ -1,0 +1,35 @@
+#include <aslam/cameras/GlobalShutter.hpp>
+
+namespace aslam {
+namespace cameras {
+GlobalShutter::GlobalShutter() {
+
+}
+
+GlobalShutter::~GlobalShutter() {
+
+}
+
+// aslam::backend compatibility
+void GlobalShutter::update(const double *) {
+
+}
+
+int GlobalShutter::minimalDimensions() const {
+  return 0;
+}
+
+void GlobalShutter::getParameters(Eigen::MatrixXd & P) const {
+  P.resize(0, 0);
+}
+
+void GlobalShutter::setParameters(const Eigen::MatrixXd & /* P */) {
+
+}
+
+Eigen::Vector2i GlobalShutter::parameterSize() const {
+  return Eigen::Vector2i(0, 0);
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/ImageMask.cpp
+++ b/deps/aslam_cameras/src/ImageMask.cpp
@@ -1,0 +1,72 @@
+#include <aslam/cameras/ImageMask.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include "sm/assert_macros.hpp"
+
+namespace aslam {
+namespace cameras {
+
+ImageMask::ImageMask()
+    : _mask(cv::Mat(0, 0, CV_8UC1)),
+      _scale(1.0)
+{}
+;
+
+ImageMask::ImageMask(const cv::Mat& mask, double scale) {
+  SM_ASSERT_EQ(std::runtime_error, mask.type(), CV_8UC1,
+               "The mask must be 8-bit one channel");
+  _mask = mask.clone();
+  _scale = scale;
+}
+
+ImageMask::~ImageMask() {
+}
+;
+
+void ImageMask::setMask(const cv::Mat& mask) {
+  SM_ASSERT_EQ(std::runtime_error, mask.type(), CV_8UC1,
+               "The mask must be 8-bit one channel");
+  _mask = mask.clone();
+}
+
+bool ImageMask::isSet() const
+{
+	return _mask.data != NULL;
+}
+
+const cv::Mat & ImageMask::getMask() const {
+  return _mask;
+}
+
+void ImageMask::setScale(double scale) {
+  _scale = scale;
+}
+
+double ImageMask::getScale() const {
+  return _scale;
+}
+
+void ImageMask::setMaskFromMatrix(const Eigen::MatrixXi & mask) {
+  _mask.create(mask.rows(), mask.cols(), CV_8UC1);
+  for (int r = 0; r < mask.rows(); ++r) {
+    uchar * p = _mask.ptr(r);
+    for (int c = 0; c < mask.cols(); ++c, ++p) {
+      *p = mask(r, c);
+    }
+  }
+}
+
+Eigen::MatrixXi ImageMask::getMaskAsMatrix() const {
+  Eigen::MatrixXi rval(_mask.rows, _mask.cols);
+
+  for (int r = 0; r < rval.rows(); ++r) {
+    const uchar * p = _mask.ptr(r);
+    for (int c = 0; c < rval.cols(); ++c, ++p) {
+      rval(r, c) = *p;
+    }
+  }
+  return rval;
+
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/MaskedCameraGeometry.cpp
+++ b/deps/aslam_cameras/src/MaskedCameraGeometry.cpp
@@ -1,0 +1,6 @@
+#include <aslam/cameras/MaskedCameraGeometry.hpp>
+
+namespace aslam {
+namespace cameras {
+}
+}

--- a/deps/aslam_cameras/src/NoDistortion.cpp
+++ b/deps/aslam_cameras/src/NoDistortion.cpp
@@ -1,0 +1,30 @@
+#include <aslam/cameras/NoDistortion.hpp>
+
+namespace aslam {
+namespace cameras {
+
+NoDistortion::NoDistortion() {
+}
+
+NoDistortion::~NoDistortion() {
+}
+
+// aslam::backend compatibility
+void NoDistortion::update(const double *) {
+
+}
+int NoDistortion::minimalDimensions() const {
+  return 0;
+}
+void NoDistortion::getParameters(Eigen::MatrixXd & P) const {
+  P.resize(0, 0);
+}
+void NoDistortion::setParameters(const Eigen::MatrixXd & /* P */) {
+}
+
+Eigen::Vector2i NoDistortion::parameterSize() const {
+  return Eigen::Vector2i(0, 0);
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/NoMask.cpp
+++ b/deps/aslam_cameras/src/NoMask.cpp
@@ -1,0 +1,13 @@
+#include<aslam/cameras/NoMask.hpp>
+
+namespace aslam {
+namespace cameras {
+
+NoMask::NoMask() {
+}
+
+NoMask::~NoMask() {
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/OmniCameraGeometry.cpp
+++ b/deps/aslam_cameras/src/OmniCameraGeometry.cpp
@@ -1,0 +1,475 @@
+#include <aslam/cameras/OmniCameraGeometry.hpp>
+#include <aslam/Exceptions.hpp>
+#include <Eigen/Dense>
+
+namespace aslam {
+namespace cameras {
+
+OmniCameraGeometry::OmniCameraGeometry() {
+  *this = createTestGeometry();
+}
+
+OmniCameraGeometry::OmniCameraGeometry(double xi, double k1, double k2,
+                                       double p1, double p2, double gamma1,
+                                       double gamma2, double u0, double v0,
+                                       int width, int height)
+    : _xi(xi),
+      _k1(k1),
+      _k2(k2),
+      _p1(p1),
+      _p2(p2),
+      _gamma1(gamma1),
+      _gamma2(gamma2),
+      _u0(u0),
+      _v0(v0),
+      _width(width),
+      _height(height) {
+  updateTemporaries();
+}
+
+OmniCameraGeometry::~OmniCameraGeometry() {
+
+}
+
+// This updates the intrinsic parameters with a small step: i <-- i + di
+// The Jacobians above are with respect to this update function.
+void OmniCameraGeometry::updateIntrinsicsOplus(double * di) {
+  _xi += di[0];
+  _k1 += di[1];
+  _k2 += di[2];
+  _p1 += di[3];
+  _p2 += di[4];
+  _gamma1 += di[5];
+  _gamma2 += di[6];
+  _u0 += di[7];
+  _v0 += di[8];
+  updateTemporaries();
+}
+
+// The amount of time elapsed between the start of the image and the
+// keypoint. For a global shutter camera, this can return Duration(0).
+Duration OmniCameraGeometry::temporalOffset(const keypoint_t & keypoint) const {
+  return Duration(0);
+}
+
+OmniCameraGeometry::keypoint_t OmniCameraGeometry::maxKeypoint() const {
+  return keypoint_t(_width, _height);
+}
+
+OmniCameraGeometry::keypoint_t OmniCameraGeometry::minKeypoint() const {
+  return keypoint_t(0, 0);
+}
+
+std::string OmniCameraGeometry::typeName() const {
+  return "OmniCamera";
+}
+
+OmniCameraGeometry OmniCameraGeometry::createTestGeometry() {
+  return OmniCameraGeometry(1.2080, -2.103030975849235e-01,
+                            1.511327079893021e-02, 6.035288960688402e-04,
+                            -5.277839371727245e-04, 5.671146836756682e+02,
+                            5.665554204210736e+02, 6.196542975873804e+02,
+                            5.106649931478771e+02, 1224, 1024);
+}
+
+/** 
+ * \brief Lifts a point from the image plane to the unit sphere
+ *
+ * \param u u image coordinate
+ * \param v v image coordinate
+ * \param X X coordinate of the point on the sphere
+ * \param Y Y coordinate of the point on the sphere
+ * \param Z Z coordinate of the point on the sphere
+ */
+void OmniCameraGeometry::lift_sphere(double u, double v, double *X, double *Y,
+                                     double *Z) const {
+  double mx_d, my_d, mx_u, my_u;
+  double lambda;
+
+  // Lift points to normalised plane
+  // Matlab points start at 1 (calibration)
+  mx_d = _inv_K11 * (u) + _inv_K13;
+  my_d = _inv_K22 * (v) + _inv_K23;
+
+  // Recursive distortion model
+  // int n = 6;
+  // double dx_u, dy_u;
+  // distortion(mx_d,my_d,&dx_u,&dy_u);
+  // // Approximate value
+  // mx_u = mx_d-dx_u;
+  // my_u = my_d-dy_u;
+
+  // for(int i=1;i<n;i++) {
+  // 	distortion(mx_u,my_u,&dx_u,&dy_u);
+  // 	mx_u = mx_d-dx_u;
+  // 	my_u = my_d-dy_u;
+  // }
+  // PTF: March 31, 2012. The above was not that accurate.
+  //      Substitute Gauss-Newton.
+  undistortGN(mx_d, my_d, &mx_u, &my_u);
+
+  // Lift normalised points to the sphere (inv_hslash)
+  lambda = (_xi + sqrt(1 + (1 - _xi * _xi) * (mx_u * mx_u + my_u * my_u)))
+      / (1 + mx_u * mx_u + my_u * my_u);
+  *X = lambda * mx_u;
+  *Y = lambda * my_u;
+  *Z = lambda - _xi;
+}
+
+/** 
+ * \brief Lifts a point from the image plane to its projective ray
+ *
+ * \param u u image coordinate
+ * \param v v image coordinate
+ * \param X X coordinate of the projective ray
+ * \param Y Y coordinate of the projective ray
+ * \param Z Z coordinate of the projective ray
+ */
+void OmniCameraGeometry::lift_projective(double u, double v, double *X,
+                                         double *Y, double *Z) const {
+  double mx_d, my_d, mx_u, my_u;
+  double rho2_d;
+
+  // Lift points to normalised plane
+  // Matlab points start at 1 (calibration)
+  mx_d = _inv_K11 * (u) + _inv_K13;
+  my_d = _inv_K22 * (v) + _inv_K23;
+
+  // Recursive distortion model
+  // int n = 8;
+  // double dx_u, dy_u;
+  // distortion(mx_d,my_d,&dx_u,&dy_u);
+  // // Approximate value
+  // mx_u = mx_d-dx_u;
+  // my_u = my_d-dy_u;
+
+  // for(int i=1;i<n;i++) {
+  // 	distortion(mx_u,my_u,&dx_u,&dy_u);
+  // 	mx_u = mx_d-dx_u;
+  // 	my_u = my_d-dy_u;
+  // }
+  // PTF: March 31, 2012. The above was not that accurate.
+  //      Substitute Gauss-Newton.
+  undistortGN(mx_d, my_d, &mx_u, &my_u);
+
+  //std::cout << "lift projective: u: " << mx_u << ", v: " << my_u << std::endl;
+
+  // Obtain a projective ray
+  // Reuse variable
+  rho2_d = mx_u * mx_u + my_u * my_u;
+  *X = mx_u;
+  *Y = my_u;
+  *Z = 1 - _xi * (rho2_d + 1) / (_xi + sqrt(1 + (1 - _xi * _xi) * rho2_d));
+
+  //std::cout << "lift projective: p: " << *X << ", " << *Y << ", " << *Z << std::endl;
+}
+
+/** 
+ * \brief Project a 3D points (\a x,\a y,\a z) to the image plane in (\a u,\a v)
+ *
+ * \param x 3D point x coordinate
+ * \param y 3D point y coordinate
+ * \param z 3D point z coordinate
+ * \param u return value, contains the image point u coordinate
+ * \param v return value, contains the image point v coordinate
+ */
+void OmniCameraGeometry::space2plane(double x, double y, double z, double *u,
+                                     double *v) const {
+  double mx_u, my_u, mx_d, my_d;
+
+  // Project points to the normalised plane
+  z = z + _xi * sqrt(x * x + y * y + z * z);
+  mx_u = x / z;
+  my_u = y / z;
+
+  // Apply distortion
+  double dx_u, dy_u;
+  distortion(mx_u, my_u, &dx_u, &dy_u);
+  mx_d = mx_u + dx_u;
+  my_d = my_u + dy_u;
+
+  // Apply generalised projection matrix
+  // Matlab points start at 1
+  *u = _gamma1 * mx_d + _u0;
+  *v = _gamma2 * my_d + _v0;
+}
+
+/** 
+ * \brief Project a 3D points (\a x,\a y,\a z) to the image plane in (\a u,\a v)
+ *        and calculate jacobian
+ *
+ * \param x 3D point x coordinate
+ * \param y 3D point y coordinate
+ * \param z 3D point z coordinate
+ * \param u return value, contains the image point u coordinate
+ * \param v return value, contains the image point v coordinate
+ */
+void OmniCameraGeometry::space2plane(double x, double y, double z, double *u,
+                                     double *v, double *dudx, double *dvdx,
+                                     double *dudy, double *dvdy, double *dudz,
+                                     double *dvdz) const {
+  double mx_u, my_u, mx_d, my_d;
+  double norm, inv_denom;
+  double dxdmx, dydmx, dxdmy, dydmy;
+
+  norm = sqrt(x * x + y * y + z * z);
+  // Project points to the normalised plane
+  inv_denom = 1 / (z + _xi * norm);
+  mx_u = inv_denom * x;
+  my_u = inv_denom * y;
+
+  // Calculate jacobian
+  inv_denom = inv_denom * inv_denom / norm;
+  *dudx = inv_denom * (norm * z + _xi * (y * y + z * z));
+  *dvdx = -inv_denom * _xi * x * y;
+  *dudy = *dvdx;
+  *dvdy = inv_denom * (norm * z + _xi * (x * x + z * z));
+  inv_denom = inv_denom * (-_xi * z - norm);  // reuse variable
+  *dudz = x * inv_denom;
+  *dvdz = y * inv_denom;
+
+  // Apply distortion
+  double dx_u, dy_u;
+  distortion(mx_u, my_u, &dx_u, &dy_u, &dxdmx, &dydmx, &dxdmy, &dydmy);
+  mx_d = mx_u + dx_u;
+  my_d = my_u + dy_u;
+
+  // Make the product of the jacobians
+  // and add projection matrix jacobian
+  inv_denom = _gamma1 * (*dudx * dxdmx + *dvdx * dxdmy);  // reuse
+  *dvdx = _gamma2 * (*dudx * dydmx + *dvdx * dydmy);
+  *dudx = inv_denom;
+
+  inv_denom = _gamma1 * (*dudy * dxdmx + *dvdy * dxdmy);  // reuse
+  *dvdy = _gamma2 * (*dudy * dydmx + *dvdy * dydmy);
+  *dudy = inv_denom;
+
+  inv_denom = _gamma1 * (*dudz * dxdmx + *dvdz * dxdmy);  // reuse
+  *dvdz = _gamma2 * (*dudz * dydmx + *dvdz * dydmy);
+  *dudz = inv_denom;
+
+  // Apply generalised projection matrix
+  // Matlab points start at 1
+  *u = _gamma1 * mx_d + _u0;
+  *v = _gamma2 * my_d + _v0;
+}
+
+/** 
+ * \brief Projects an undistorted 2D point (\a mx_u,\a my_u) to the image plane in (\a u,\a v)
+ *
+ * \param mx_u 2D point x coordinate
+ * \param my_u 3D point y coordinate
+ * \param u return value, contains the image point u coordinate
+ * \param v return value, contains the image point v coordinate
+ */
+void OmniCameraGeometry::undist2plane(double mx_u, double my_u, double *u,
+                                      double *v) const {
+  double mx_d, my_d;
+
+  // Apply distortion
+  double dx_u, dy_u;
+  distortion(mx_u, my_u, &dx_u, &dy_u);
+  mx_d = mx_u + dx_u;
+  my_d = my_u + dy_u;
+
+  // Apply generalised projection matrix
+  // Matlab points start at 1
+  *u = _gamma1 * mx_d + _u0;
+  *v = _gamma2 * my_d + _v0;
+}
+
+/** 
+ * \brief Apply distortion to input point (from the normalised plane)
+ *  
+ * \param mx_u undistorted x coordinate of point on the normalised plane
+ * \param my_u undistorted y coordinate of point on the normalised plane
+ * \param dx return value, to obtain the distorted point : mx_d = mx_u+dx_u
+ * \param dy return value, to obtain the distorted point : my_d = my_u+dy_u
+ */
+void OmniCameraGeometry::distortion(double mx_u, double my_u, double *dx_u,
+                                    double *dy_u) const {
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = mx_u * mx_u;
+  my2_u = my_u * my_u;
+  mxy_u = mx_u * my_u;
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  *dx_u = mx_u * rad_dist_u + 2 * _p1 * mxy_u + _p2 * (rho2_u + 2 * mx2_u);
+  *dy_u = my_u * rad_dist_u + 2 * _p2 * mxy_u + _p1 * (rho2_u + 2 * my2_u);
+}
+
+/** 
+ * \brief Apply distortion to input point (from the normalised plane)
+ *        and calculate jacobian
+ *
+ * \param mx_u undistorted x coordinate of point on the normalised plane
+ * \param my_u undistorted y coordinate of point on the normalised plane
+ * \param dx return value, to obtain the distorted point : mx_d = mx_u+dx_u
+ * \param dy return value, to obtain the distorted point : my_d = my_u+dy_u
+ */
+void OmniCameraGeometry::distortion(double mx_u, double my_u, double *dx_u,
+                                    double *dy_u, double *dxdmx, double *dydmx,
+                                    double *dxdmy, double *dydmy) const {
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = mx_u * mx_u;
+  my2_u = my_u * my_u;
+  mxy_u = mx_u * my_u;
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  *dx_u = mx_u * rad_dist_u + 2 * _p1 * mxy_u + _p2 * (rho2_u + 2 * mx2_u);
+  *dy_u = my_u * rad_dist_u + 2 * _p2 * mxy_u + _p1 * (rho2_u + 2 * my2_u);
+
+  *dxdmx = 1 + rad_dist_u + _k1 * 2 * mx2_u + _k2 * rho2_u * 4 * mx2_u
+      + 2 * _p1 * my_u + 6 * _p2 * mx_u;
+  *dydmx = _k1 * 2 * mx_u * my_u + _k2 * 4 * rho2_u * mx_u * my_u
+      + _p1 * 2 * mx_u + 2 * _p2 * my_u;
+  *dxdmy = *dydmx;
+  *dydmy = 1 + rad_dist_u + _k1 * 2 * my2_u + _k2 * rho2_u * 4 * my2_u
+      + 6 * _p1 * my_u + 2 * _p2 * mx_u;
+}
+
+void OmniCameraGeometry::updateTemporaries() {
+  // Inverse camera projection matrix parameters
+  _inv_K11 = 1.0 / _gamma1;
+  _inv_K13 = -_u0 / _gamma1;
+  _inv_K22 = 1.0 / _gamma2;
+  _inv_K23 = -_v0 / _gamma2;
+  _one_over_xixi_m_1 = 1.0 / (_xi * _xi - 1.0);
+
+}
+
+void OmniCameraGeometry::setIntrinsicsVectorImplementation(
+    const Eigen::VectorXd & V) {
+  _xi = V[0];
+  _k1 = V[1];
+  _k2 = V[2];
+  _p1 = V[3];
+  _p2 = V[4];
+  _gamma1 = V[5];
+  _gamma2 = V[6];
+  _u0 = V[7];
+  _v0 = V[8];
+  updateTemporaries();
+
+}
+
+Eigen::VectorXd OmniCameraGeometry::getIntrinsicsVectorImplementation() const {
+  Eigen::VectorXd V(9);
+  V[0] = _xi;
+  V[1] = _k1;
+  V[2] = _k2;
+  V[3] = _p1;
+  V[4] = _p2;
+  V[5] = _gamma1;
+  V[6] = _gamma2;
+  V[7] = _u0;
+  V[8] = _v0;
+  return V;
+}
+
+Eigen::Matrix3d OmniCameraGeometry::getCameraMatrix() const {
+  Eigen::Matrix3d K;
+  K << _gamma1, 0, _u0, 0, _gamma2, _v0, 0, 0, 1;
+  return K;
+}
+
+Eigen::VectorXd OmniCameraGeometry::createRandomKeypoint() const {
+  // This is tricky...The camera model defines a circle on the normalized image
+  // plane and the projection equations don't work outside of it.
+  // With some manipulation, we can see that, on the normalized image plane,
+  // the edge of this circle is at u^2 + v^2 = 1/(xi^2 - 1)
+  // So: this function creates keypoints inside this boundary.
+
+  // Create a point on the normalized image plane inside the boundary.
+  // This is not efficient, but it should be correct.
+
+  Eigen::Vector2d u(width() + 1, height() + 1);
+
+  while (u[0] < 0 || u[0] > width() - 1 || u[1] < 0 || u[1] > height() - 1) {
+    u.setRandom();
+    u = u - Eigen::Vector2d(0.5, 0.5);
+    u /= u.norm();
+    u *= ((double) rand() / (double) RAND_MAX) * _one_over_xixi_m_1;
+
+    // Now we run the point through distortion and projection.
+    // Apply distortion
+    double dx_u, dy_u;
+    distortion(u[0], u[1], &dx_u, &dy_u);
+    double mx_d = u[0] + dx_u;
+    double my_d = u[1] + dy_u;
+
+    // Apply generalised projection matrix
+    // Matlab points start at 1
+    u[0] = _gamma1 * mx_d + _u0;
+    u[1] = _gamma2 * my_d + _v0;
+  }
+
+  // I would like to do this below but it is way, way worse than above.
+  // // The output
+  // Eigen::Vector2d u;
+  // // The output projected to the normalized image plane.
+  // Eigen::Vector2d u_norm;
+
+  // // The singularity radius minus an epsilon
+  // double nRadius = 1.0/_one_over_xixi_m_1;
+
+  // do
+  // 	{
+  // 	  // Create a random keypoint in the image.
+  // 	  //u.setRandom();
+  // 	  u[0] = ( (double)rand() / (double)RAND_MAX)*_width;
+  // 	  u[1] = ( (double)rand() / (double)RAND_MAX)*_height;
+
+  // 	  // Lift points to normalised plane
+  // 	  // Matlab points start at 1 (calibration)
+  // 	  double u0_d = _inv_K11*(u[0])+_inv_K13;
+  // 	  double u1_d = _inv_K22*(u[1])+_inv_K23;
+  // 	  undistortGN(u0_d, u1_d, &u_norm[0], &u_norm[1]);
+
+  // 	}
+  // while( u_norm.dot(u_norm) >= nRadius );
+
+  return u;
+}
+
+// Use Gauss-Newton to undistort.
+void OmniCameraGeometry::undistortGN(double u_d, double v_d, double * u,
+                                     double * v) const {
+  *u = u_d;
+  *v = v_d;
+
+  double ubar = u_d;
+  double vbar = v_d;
+  const int n = 5;
+  Eigen::Matrix2d F;
+
+  double hat_u_d;
+  double hat_v_d;
+
+  // void OmniCameraGeometry::distortion(double mx_u, double my_u, 
+  // 					  double *dx_u, double *dy_u,
+  // 					  double *dxdmx, double *dydmx,
+  // 					  double *dxdmy, double *dydmy) const
+  for (int i = 0; i < n; i++) {
+    distortion(ubar, vbar, &hat_u_d, &hat_v_d, &F(0, 0), &F(1, 0), &F(0, 1),
+               &F(1, 1));
+
+    Eigen::Vector2d e(u_d - ubar - hat_u_d, v_d - vbar - hat_v_d);
+    Eigen::Vector2d du = (F.transpose() * F).inverse() * F.transpose() * e;
+
+    ubar += du[0];
+    vbar += du[1];
+
+    if (e.dot(e) < 1e-15)
+      break;
+
+  }
+  *u = ubar;
+  *v = vbar;
+}
+
+}  // namespace cameras
+
+    }  // namespace aslam

--- a/deps/aslam_cameras/src/PinholeCameraGeometry.cpp
+++ b/deps/aslam_cameras/src/PinholeCameraGeometry.cpp
@@ -1,0 +1,208 @@
+#include <aslam/cameras.hpp>
+#include <aslam/Exceptions.hpp>
+#include <Eigen/Dense>
+
+namespace aslam {
+namespace cameras {
+
+PinholeCameraGeometry::PinholeCameraGeometry() {
+  *this = createTestGeometry();
+}
+
+PinholeCameraGeometry::PinholeCameraGeometry(double focalLengthU,
+                                             double focalLengthV,
+                                             double imageCenterU,
+                                             double imageCenterV,
+                                             int resolutionU, int resolutionV)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _enableDistortion(0),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv) {
+  // 0
+}
+
+PinholeCameraGeometry::PinholeCameraGeometry(double focalLengthU,
+                                             double focalLengthV,
+                                             double imageCenterU,
+                                             double imageCenterV,
+                                             int resolutionU, int resolutionV,
+                                             double k1, double k2, double p1,
+                                             double p2)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _k1(k1),
+      _k2(k2),
+      _p1(p1),
+      _p2(p2),
+      _enableDistortion(1),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv) {
+  // 0
+}
+
+PinholeCameraGeometry::~PinholeCameraGeometry() {
+
+}
+
+// This updates the intrinsic parameters with a small step: i <-- i + di
+// The Jacobians above are with respect to this update function.
+void PinholeCameraGeometry::updateIntrinsicsOplus(double * di) {
+  SM_THROW(NotImplementedException,
+           "The pinhole camera object does not support optimizing intrinsics");
+}
+
+// The amount of time elapsed between the start of the image and the
+// keypoint. For a global shutter camera, this can return Duration(0).
+Duration PinholeCameraGeometry::temporalOffset(
+    const keypoint_t & keypoint) const {
+  return Duration(0);
+}
+
+PinholeCameraGeometry::keypoint_t PinholeCameraGeometry::maxKeypoint() const {
+  return keypoint_t(_ru, _rv);
+}
+
+PinholeCameraGeometry::keypoint_t PinholeCameraGeometry::minKeypoint() const {
+  return keypoint_t(0, 0);
+}
+
+std::string PinholeCameraGeometry::typeName() const {
+  return "PinholeCamera";
+}
+
+PinholeCameraGeometry PinholeCameraGeometry::createTestGeometry() {
+  return PinholeCameraGeometry(400, 400, 320, 240, 640, 480);  // ,0.2,0.2,0.2,0.2
+}
+
+PinholeCameraGeometry PinholeCameraGeometry::createDistortedTestGeometry() {
+  return PinholeCameraGeometry(400, 400, 320, 240, 640, 480, 0.2, 0.2, 0.2, 0.2);
+}
+
+/**
+ * \brief Apply distortion to input point (from the normalised plane)
+ *
+ * \param mx_u undistorted x coordinate of point on the normalised plane
+ * \param my_u undistorted y coordinate of point on the normalised plane
+ * \param dx return value, to obtain the distorted point : mx_d = mx_u+dx_u
+ * \param dy return value, to obtain the distorted point : my_d = my_u+dy_u
+ */
+void PinholeCameraGeometry::distortion(double mx_u, double my_u, double *dx_u,
+                                       double *dy_u) const {
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = mx_u * mx_u;
+  my2_u = my_u * my_u;
+  mxy_u = mx_u * my_u;
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  *dx_u = mx_u * rad_dist_u + 2 * _p1 * mxy_u + _p2 * (rho2_u + 2 * mx2_u);
+  *dy_u = my_u * rad_dist_u + 2 * _p2 * mxy_u + _p1 * (rho2_u + 2 * my2_u);
+}
+
+/**
+ * \brief Apply distortion to input point (from the normalised plane)
+ *        and calculate jacobian
+ *
+ * \param mx_u undistorted x coordinate of point on the normalised plane
+ * \param my_u undistorted y coordinate of point on the normalised plane
+ * \param dx return value, to obtain the distorted point : mx_d = mx_u+dx_u
+ * \param dy return value, to obtain the distorted point : my_d = my_u+dy_u
+ */
+void PinholeCameraGeometry::distortion(double mx_u, double my_u, double *dx_u,
+                                       double *dy_u, double *dxdmx,
+                                       double *dydmx, double *dxdmy,
+                                       double *dydmy) const {
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = mx_u * mx_u;
+  my2_u = my_u * my_u;
+  mxy_u = mx_u * my_u;
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  *dx_u = mx_u * rad_dist_u + 2 * _p1 * mxy_u + _p2 * (rho2_u + 2 * mx2_u);
+  *dy_u = my_u * rad_dist_u + 2 * _p2 * mxy_u + _p1 * (rho2_u + 2 * my2_u);
+
+  *dxdmx = 1 + rad_dist_u + _k1 * 2 * mx2_u + _k2 * rho2_u * 4 * mx2_u
+      + 2 * _p1 * my_u + 6 * _p2 * mx_u;
+  *dydmx = _k1 * 2 * mx_u * my_u + _k2 * 4 * rho2_u * mx_u * my_u
+      + _p1 * 2 * mx_u + 2 * _p2 * my_u;
+  *dxdmy = *dydmx;
+  *dydmy = 1 + rad_dist_u + _k1 * 2 * my2_u + _k2 * rho2_u * 4 * my2_u
+      + 6 * _p1 * my_u + 2 * _p2 * mx_u;
+}
+
+// Use Gauss-Newton to undistort.
+void PinholeCameraGeometry::undistortGN(double u_d, double v_d, double * u,
+                                        double * v) const {
+  *u = u_d;
+  *v = v_d;
+
+  double ubar = u_d;
+  double vbar = v_d;
+  const int n = 5;
+  Eigen::Matrix2d F;
+
+  double hat_u_d;
+  double hat_v_d;
+
+  for (int i = 0; i < n; i++) {
+    distortion(ubar, vbar, &hat_u_d, &hat_v_d, &F(0, 0), &F(1, 0), &F(0, 1),
+               &F(1, 1));
+
+    Eigen::Vector2d e(u_d - ubar - hat_u_d, v_d - vbar - hat_v_d);
+    Eigen::Vector2d du = (F.transpose() * F).inverse() * F.transpose() * e;
+
+    ubar += du[0];
+    vbar += du[1];
+
+    if (e.dot(e) < 1e-15)
+      break;
+
+  }
+  *u = ubar;
+  *v = vbar;
+}
+
+void PinholeCameraGeometry::setIntrinsicsVectorImplementation(
+    const PinholeCameraGeometry::traits_t::intrinsics_t & intrinsics) {
+  _fu = intrinsics(0);
+  _fv = intrinsics(1);
+  _cu = intrinsics(2);
+  _cv = intrinsics(3);
+  _k1 = intrinsics(4);
+  _k2 = intrinsics(5);
+  _p1 = intrinsics(6);
+  _p2 = intrinsics(7);
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+
+}
+
+PinholeCameraGeometry::traits_t::intrinsics_t PinholeCameraGeometry::getIntrinsicsVectorImplementation() const {
+  traits_t::intrinsics_t intrinsics;
+  intrinsics(0) = _fu;
+  intrinsics(1) = _fv;
+  intrinsics(2) = _cu;
+  intrinsics(3) = _cv;
+  intrinsics(4) = _k1;
+  intrinsics(5) = _k2;
+  intrinsics(6) = _p1;
+  intrinsics(7) = _p2;
+  return intrinsics;
+}
+
+}  // namespace cameras
+
+}  // namespace aslam

--- a/deps/aslam_cameras/src/PinholeRSCameraGeometry.cpp
+++ b/deps/aslam_cameras/src/PinholeRSCameraGeometry.cpp
@@ -1,0 +1,222 @@
+// src
+// Luc Oth 04/12
+// othlu@student.ethz.ch
+
+#include <aslam/cameras/PinholeRSCameraGeometry.hpp>
+#include <aslam/Exceptions.hpp>
+#include <Eigen/Dense>
+
+namespace aslam {
+namespace cameras {
+
+PinholeRSCameraGeometry::PinholeRSCameraGeometry() {
+  *this = createTestGeometry();
+}
+
+PinholeRSCameraGeometry::PinholeRSCameraGeometry(double focalLengthU,
+                                                 double focalLengthV,
+                                                 double imageCenterU,
+                                                 double imageCenterV,
+                                                 int resolutionU,
+                                                 int resolutionV,
+                                                 double lineDelay)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _enableDistortion(0),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv),
+      _lineDelay(lineDelay) {
+  // 0
+}
+
+PinholeRSCameraGeometry::PinholeRSCameraGeometry(double focalLengthU,
+                                                 double focalLengthV,
+                                                 double imageCenterU,
+                                                 double imageCenterV,
+                                                 int resolutionU,
+                                                 int resolutionV,
+                                                 double lineDelay, double k1,
+                                                 double k2, double p1,
+                                                 double p2)
+    : _fu(focalLengthU),
+      _fv(focalLengthV),
+      _cu(imageCenterU),
+      _cv(imageCenterV),
+      _ru(resolutionU),
+      _rv(resolutionV),
+      _k1(k1),
+      _k2(k2),
+      _p1(p1),
+      _p2(p2),
+      _enableDistortion(1),
+      _recip_fu(1.0 / _fu),
+      _recip_fv(1.0 / _fv),
+      _fu_over_fv(_fu / _fv),
+      _lineDelay(lineDelay) {
+  // 0
+}
+
+PinholeRSCameraGeometry::~PinholeRSCameraGeometry() {
+
+}
+
+// This updates the intrinsic parameters with a small step: i <-- i + di
+// The Jacobians above are with respect to this update function.
+void PinholeRSCameraGeometry::updateIntrinsicsOplus(double * di) {
+  SM_THROW(NotImplementedException,
+           "The pinhole camera object does not support optimizing intrinsics");
+}
+
+// The amount of time elapsed between the start of the image and the
+// keypoint. For a global shutter camera, this can return Duration(0).
+Duration PinholeRSCameraGeometry::temporalOffset(
+    const keypoint_t & keypoint) const {
+
+  // time offset only depends on the line => keypoint(1)
+  return Duration(_lineDelay * keypoint(1));
+
+}
+
+PinholeRSCameraGeometry::keypoint_t PinholeRSCameraGeometry::maxKeypoint() const {
+  return keypoint_t(_ru, _rv);
+}
+
+PinholeRSCameraGeometry::keypoint_t PinholeRSCameraGeometry::minKeypoint() const {
+  return keypoint_t(0, 0);
+}
+
+std::string PinholeRSCameraGeometry::typeName() const {
+  return "PinholeRSCamera";
+}
+
+PinholeRSCameraGeometry PinholeRSCameraGeometry::createTestGeometry() {
+  return PinholeRSCameraGeometry(400, 400, 320, 240, 640, 480, 0.0005);
+}
+
+PinholeRSCameraGeometry PinholeRSCameraGeometry::createDistortedTestGeometry() {
+  return PinholeRSCameraGeometry(400, 400, 320, 240, 640, 480, 0.0005, 0.2, 0.2,
+                                 0.2, 0.2);
+}
+
+/** 
+ * \brief Apply distortion to input point (from the normalised plane)
+ *  
+ * \param mx_u undistorted x coordinate of point on the normalised plane
+ * \param my_u undistorted y coordinate of point on the normalised plane
+ * \param dx return value, to obtain the distorted point : mx_d = mx_u+dx_u
+ * \param dy return value, to obtain the distorted point : my_d = my_u+dy_u
+ */
+void PinholeRSCameraGeometry::distortion(double mx_u, double my_u, double *dx_u,
+                                         double *dy_u) const {
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = mx_u * mx_u;
+  my2_u = my_u * my_u;
+  mxy_u = mx_u * my_u;
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  *dx_u = mx_u * rad_dist_u + 2 * _p1 * mxy_u + _p2 * (rho2_u + 2 * mx2_u);
+  *dy_u = my_u * rad_dist_u + 2 * _p2 * mxy_u + _p1 * (rho2_u + 2 * my2_u);
+}
+
+/** 
+ * \brief Apply distortion to input point (from the normalised plane)
+ *        and calculate jacobian
+ *
+ * \param mx_u undistorted x coordinate of point on the normalised plane
+ * \param my_u undistorted y coordinate of point on the normalised plane
+ * \param dx return value, to obtain the distorted point : mx_d = mx_u+dx_u
+ * \param dy return value, to obtain the distorted point : my_d = my_u+dy_u
+ */
+void PinholeRSCameraGeometry::distortion(double mx_u, double my_u, double *dx_u,
+                                         double *dy_u, double *dxdmx,
+                                         double *dydmx, double *dxdmy,
+                                         double *dydmy) const {
+  double mx2_u, my2_u, mxy_u, rho2_u, rad_dist_u;
+
+  mx2_u = mx_u * mx_u;
+  my2_u = my_u * my_u;
+  mxy_u = mx_u * my_u;
+  rho2_u = mx2_u + my2_u;
+  rad_dist_u = _k1 * rho2_u + _k2 * rho2_u * rho2_u;
+  *dx_u = mx_u * rad_dist_u + 2 * _p1 * mxy_u + _p2 * (rho2_u + 2 * mx2_u);
+  *dy_u = my_u * rad_dist_u + 2 * _p2 * mxy_u + _p1 * (rho2_u + 2 * my2_u);
+
+  *dxdmx = 1 + rad_dist_u + _k1 * 2 * mx2_u + _k2 * rho2_u * 4 * mx2_u
+      + 2 * _p1 * my_u + 6 * _p2 * mx_u;
+  *dydmx = _k1 * 2 * mx_u * my_u + _k2 * 4 * rho2_u * mx_u * my_u
+      + _p1 * 2 * mx_u + 2 * _p2 * my_u;
+  *dxdmy = *dydmx;
+  *dydmy = 1 + rad_dist_u + _k1 * 2 * my2_u + _k2 * rho2_u * 4 * my2_u
+      + 6 * _p1 * my_u + 2 * _p2 * mx_u;
+}
+
+// Use Gauss-Newton to undistort.
+void PinholeRSCameraGeometry::undistortGN(double u_d, double v_d, double * u,
+                                          double * v) const {
+  *u = u_d;
+  *v = v_d;
+
+  double ubar = u_d;
+  double vbar = v_d;
+  const int n = 5;
+  Eigen::Matrix2d F;
+
+  double hat_u_d;
+  double hat_v_d;
+
+  for (int i = 0; i < n; i++) {
+    distortion(ubar, vbar, &hat_u_d, &hat_v_d, &F(0, 0), &F(1, 0), &F(0, 1),
+               &F(1, 1));
+
+    Eigen::Vector2d e(u_d - ubar - hat_u_d, v_d - vbar - hat_v_d);
+    Eigen::Vector2d du = (F.transpose() * F).inverse() * F.transpose() * e;
+
+    ubar += du[0];
+    vbar += du[1];
+
+    if (e.dot(e) < 1e-15)
+      break;
+
+  }
+  *u = ubar;
+  *v = vbar;
+}
+
+void PinholeRSCameraGeometry::setIntrinsicsVectorImplementation(
+    const PinholeRSCameraGeometry::traits_t::intrinsics_t & intrinsics) {
+  _fu = intrinsics(0);
+  _fv = intrinsics(1);
+  _cu = intrinsics(2);
+  _cv = intrinsics(3);
+  _k1 = intrinsics(4);
+  _k2 = intrinsics(5);
+  _p1 = intrinsics(6);
+  _p2 = intrinsics(7);
+  _recip_fu = 1.0 / _fu;
+  _recip_fv = 1.0 / _fv;
+  _fu_over_fv = _fu / _fv;
+
+}
+
+PinholeRSCameraGeometry::traits_t::intrinsics_t PinholeRSCameraGeometry::getIntrinsicsVectorImplementation() const {
+  traits_t::intrinsics_t intrinsics;
+  intrinsics(0) = _fu;
+  intrinsics(1) = _fv;
+  intrinsics(2) = _cu;
+  intrinsics(3) = _cv;
+  intrinsics(4) = _k1;
+  intrinsics(5) = _k2;
+  intrinsics(6) = _p1;
+  intrinsics(7) = _p2;
+  return intrinsics;
+}
+
+}  // namespace cameras  
+
+}  // namespace aslam

--- a/deps/aslam_cameras/src/RadialTangentialDistortion.cpp
+++ b/deps/aslam_cameras/src/RadialTangentialDistortion.cpp
@@ -1,0 +1,63 @@
+#include <aslam/cameras/RadialTangentialDistortion.hpp>
+
+namespace aslam {
+namespace cameras {
+
+RadialTangentialDistortion::RadialTangentialDistortion()
+    : _k1(0),
+      _k2(0),
+      _p1(0),
+      _p2(0) {
+
+}
+
+RadialTangentialDistortion::RadialTangentialDistortion(double k1, double k2,
+                                                       double p1, double p2)
+    : _k1(k1),
+      _k2(k2),
+      _p1(p1),
+      _p2(p2) {
+
+}
+
+RadialTangentialDistortion::~RadialTangentialDistortion() {
+
+}
+
+// aslam::backend compatibility
+void RadialTangentialDistortion::update(const double * v) {
+  _k1 += v[0];
+  _k2 += v[1];
+  _p1 += v[2];
+  _p2 += v[3];
+}
+
+int RadialTangentialDistortion::minimalDimensions() const {
+  return IntrinsicsDimension;
+}
+
+void RadialTangentialDistortion::getParameters(Eigen::MatrixXd & S) const {
+  S.resize(4, 1);
+  S(0, 0) = _k1;
+  S(1, 0) = _k2;
+  S(2, 0) = _p1;
+  S(3, 0) = _p2;
+}
+
+void RadialTangentialDistortion::setParameters(const Eigen::MatrixXd & S) {
+  _k1 = S(0, 0);
+  _k2 = S(1, 0);
+  _p1 = S(2, 0);
+  _p2 = S(3, 0);
+}
+
+Eigen::Vector2i RadialTangentialDistortion::parameterSize() const {
+  return Eigen::Vector2i(4, 1);
+}
+
+RadialTangentialDistortion RadialTangentialDistortion::getTestDistortion() {
+  return RadialTangentialDistortion(-0.2, 0.13, 0.0005, 0.0005);
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/RollingShutter.cpp
+++ b/deps/aslam_cameras/src/RollingShutter.cpp
@@ -1,0 +1,51 @@
+#include <aslam/cameras/RollingShutter.hpp>
+#include "sm/assert_macros.hpp"
+
+namespace aslam {
+namespace cameras {
+RollingShutter::RollingShutter()
+    : _lineDelay(0.0) {
+
+}
+
+RollingShutter::RollingShutter(double lineDelay)
+    : _lineDelay(lineDelay) {
+
+}
+
+RollingShutter::~RollingShutter() {
+
+}
+
+// aslam::backend compatibility
+void RollingShutter::update(const double * v) {
+  _lineDelay += v[0];
+}
+
+int RollingShutter::minimalDimensions() const {
+  return 1;
+}
+
+void RollingShutter::getParameters(Eigen::MatrixXd & P) const {
+  P.resize(1, 1);
+  P(0, 0) = _lineDelay;
+}
+
+void RollingShutter::setParameters(const Eigen::MatrixXd & P) {
+  SM_ASSERT_GT(std::runtime_error, P.rows(), 0,
+               "There must be at least one element in the matrix");
+  SM_ASSERT_GT(std::runtime_error, P.cols(), 0,
+               "There must be at least one element in the matrix");
+  _lineDelay = P(0, 0);
+}
+
+Eigen::Vector2i RollingShutter::parameterSize() const {
+  return Eigen::Vector2i(1, 1);
+}
+
+RollingShutter RollingShutter::getTestShutter() {
+  return RollingShutter(10e-5);
+}
+
+}  // namespace cameras
+}  // namespace aslam

--- a/deps/aslam_cameras/src/SphericalCameraGeometry.cpp
+++ b/deps/aslam_cameras/src/SphericalCameraGeometry.cpp
@@ -1,0 +1,392 @@
+#include <aslam/cameras/SphericalCameraGeometry.hpp>
+#include <aslam/Exceptions.hpp>
+#include <Eigen/Dense>
+
+namespace aslam {
+namespace cameras {
+
+SphericalCameraGeometry::SphericalCameraGeometry() {
+  *this = createTestGeometry();
+}
+
+SphericalCameraGeometry::SphericalCameraGeometry(double xi, double gamma1,
+                                                 double gamma2, double u0,
+                                                 double v0, int width,
+                                                 int height)
+    : _xi(xi),
+      _gamma1(gamma1),
+      _gamma2(gamma2),
+      _u0(u0),
+      _v0(v0),
+      _width(width),
+      _height(height) {
+  updateTemporaries();
+}
+
+SphericalCameraGeometry::~SphericalCameraGeometry() {
+
+}
+
+// This updates the intrinsic parameters with a small step: i <-- i + di
+// The Jacobians above are with respect to this update function.
+void SphericalCameraGeometry::updateIntrinsicsOplus(double * di) {
+  _xi += di[0];
+  // MN: This offset (4 empty entries) is not nice, but provides a
+  // common interface with OmniCameras
+  _gamma1 += di[5];
+  _gamma2 += di[6];
+  _u0 += di[7];
+  _v0 += di[8];
+  updateTemporaries();
+}
+
+// The amount of time elapsed between the start of the image and the
+// keypoint. For a global shutter camera, this can return Duration(0).
+Duration SphericalCameraGeometry::temporalOffset(
+    const keypoint_t & keypoint) const {
+  return Duration(0);
+}
+
+SphericalCameraGeometry::keypoint_t SphericalCameraGeometry::maxKeypoint() const {
+  return keypoint_t(_width, _height);
+}
+
+SphericalCameraGeometry::keypoint_t SphericalCameraGeometry::minKeypoint() const {
+  return keypoint_t(0, 0);
+}
+
+std::string SphericalCameraGeometry::typeName() const {
+  return "SphericalCamera";
+}
+
+SphericalCameraGeometry SphericalCameraGeometry::createTestGeometry() {
+  return SphericalCameraGeometry(1.2080, 5.671146836756682e+02,
+                                 5.665554204210736e+02, 6.196542975873804e+02,
+                                 5.106649931478771e+02, 1224, 1024);
+}
+
+/** 
+ * \brief Lifts a point from the image plane to the unit sphere
+ *
+ * \param u u image coordinate
+ * \param v v image coordinate
+ * \param X X coordinate of the point on the sphere
+ * \param Y Y coordinate of the point on the sphere
+ * \param Z Z coordinate of the point on the sphere
+ */
+void SphericalCameraGeometry::lift_sphere(double u, double v, double *X,
+                                          double *Y, double *Z) const {
+  double mx_u, my_u;
+  double lambda;
+
+  // Lift points to normalised plane
+  // Matlab points start at 1 (calibration)
+  mx_u = _inv_K11 * (u) + _inv_K13;
+  my_u = _inv_K22 * (v) + _inv_K23;
+
+  // Recursive distortion model
+  // int n = 6;
+  // double dx_u, dy_u;
+  // distortion(mx_d,my_d,&dx_u,&dy_u);
+  // // Approximate value
+  // mx_u = mx_d-dx_u;
+  // my_u = my_d-dy_u;
+
+  // for(int i=1;i<n;i++) {
+  // 	distortion(mx_u,my_u,&dx_u,&dy_u);
+  // 	mx_u = mx_d-dx_u;
+  // 	my_u = my_d-dy_u;
+  // }
+  // PTF: March 31, 2012. The above was not that accurate.
+  //      Substitute Gauss-Newton.
+  //undistortGN(mx_d, my_d, &mx_u, &my_u);
+
+  // Lift normalised points to the sphere (inv_hslash)
+  lambda = (_xi + sqrt(1 + (1 - _xi * _xi) * (mx_u * mx_u + my_u * my_u)))
+      / (1 + mx_u * mx_u + my_u * my_u);
+  *X = lambda * mx_u;
+  *Y = lambda * my_u;
+  *Z = lambda - _xi;
+}
+
+/** 
+ * \brief Lifts a point from the image plane to its projective ray
+ *
+ * \param u u image coordinate
+ * \param v v image coordinate
+ * \param X X coordinate of the projective ray
+ * \param Y Y coordinate of the projective ray
+ * \param Z Z coordinate of the projective ray
+ */
+void SphericalCameraGeometry::lift_projective(double u, double v, double *X,
+                                              double *Y, double *Z) const {
+  double mx_u, my_u;
+  double rho2_d;
+
+  // Lift points to normalised plane
+  // Matlab points start at 1 (calibration)
+  mx_u = _inv_K11 * (u) + _inv_K13;
+  my_u = _inv_K22 * (v) + _inv_K23;
+
+  // Recursive distortion model
+  // int n = 8;
+  // double dx_u, dy_u;
+  // distortion(mx_d,my_d,&dx_u,&dy_u);
+  // // Approximate value
+  // mx_u = mx_d-dx_u;
+  // my_u = my_d-dy_u;
+
+  // for(int i=1;i<n;i++) {
+  // 	distortion(mx_u,my_u,&dx_u,&dy_u);
+  // 	mx_u = mx_d-dx_u;
+  // 	my_u = my_d-dy_u;
+  // }
+  // PTF: March 31, 2012. The above was not that accurate.
+  //      Substitute Gauss-Newton.
+  //undistortGN(mx_d, my_d, &mx_u, &my_u);
+
+  //std::cout << "lift projective: u: " << mx_u << ", v: " << my_u << std::endl;
+
+  // Obtain a projective ray
+  // Reuse variable
+  rho2_d = mx_u * mx_u + my_u * my_u;
+  *X = mx_u;
+  *Y = my_u;
+  *Z = 1 - _xi * (rho2_d + 1) / (_xi + sqrt(1 + (1 - _xi * _xi) * rho2_d));
+
+  //std::cout << "lift projective: p: " << *X << ", " << *Y << ", " << *Z << std::endl;
+}
+
+/** 
+ * \brief Project a 3D points (\a x,\a y,\a z) to the image plane in (\a u,\a v)
+ *
+ * \param x 3D point x coordinate
+ * \param y 3D point y coordinate
+ * \param z 3D point z coordinate
+ * \param u return value, contains the image point u coordinate
+ * \param v return value, contains the image point v coordinate
+ */
+void SphericalCameraGeometry::space2plane(double x, double y, double z,
+                                          double *u, double *v) const {
+  double mx_u, my_u;
+
+  // Project points to the normalised plane
+  z = z + _xi * sqrt(x * x + y * y + z * z);
+  mx_u = x / z;
+  my_u = y / z;
+
+  /*
+   // Apply distortion
+   double dx_u, dy_u;
+   distortion(mx_u,my_u,&dx_u,&dy_u);
+   mx_d = mx_u+dx_u;
+   my_d = my_u+dy_u;
+   */
+
+  // Apply generalised projection matrix
+  // Matlab points start at 1
+  *u = _gamma1 * mx_u + _u0;
+  *v = _gamma2 * my_u + _v0;
+}
+
+/** 
+ * \brief Project a 3D points (\a x,\a y,\a z) to the image plane in (\a u,\a v)
+ *        and calculate jacobian
+ *
+ * \param x 3D point x coordinate
+ * \param y 3D point y coordinate
+ * \param z 3D point z coordinate
+ * \param u return value, contains the image point u coordinate
+ * \param v return value, contains the image point v coordinate
+ */
+void SphericalCameraGeometry::space2plane(double x, double y, double z,
+                                          double *u, double *v, double *dudx,
+                                          double *dvdx, double *dudy,
+                                          double *dvdy, double *dudz,
+                                          double *dvdz) const {
+
+  SM_THROW(std::runtime_error, "Not implemented");
+  double mx_u, my_u;
+  double norm, inv_denom;
+  //double dxdmx, dydmx, dxdmy, dydmy;
+
+  norm = sqrt(x * x + y * y + z * z);
+  // Project points to the normalised plane
+  inv_denom = 1 / (z + _xi * norm);
+  mx_u = inv_denom * x;
+  my_u = inv_denom * y;
+
+  // Calculate jacobian
+  inv_denom = inv_denom * inv_denom / norm;
+  *dudx = inv_denom * (norm * z + _xi * (y * y + z * z));
+  *dvdx = -inv_denom * _xi * x * y;
+  *dudy = *dvdx;
+  *dvdy = inv_denom * (norm * z + _xi * (x * x + z * z));
+  inv_denom = inv_denom * (-_xi * z - norm);  // reuse variable
+  *dudz = x * inv_denom;
+  *dvdz = y * inv_denom;
+
+  // Apply distortion
+  /*
+   double dx_u, dy_u;
+   distortion(mx_u,my_u,&dx_u,&dy_u,&dxdmx,&dydmx,&dxdmy,&dydmy);
+   mx_d = mx_u+dx_u;
+   my_d = my_u+dy_u;
+   */
+
+  // Make the product of the jacobians
+  // and add projection matrix jacobian
+  inv_denom = _gamma1 * (*dudx + *dvdx);  // reuse
+  *dvdx = _gamma2 * (*dudx + *dvdx);
+  *dudx = inv_denom;
+
+  inv_denom = _gamma1 * (*dudy + *dvdy);  // reuse
+  *dvdy = _gamma2 * (*dudy + *dvdy);
+  *dudy = inv_denom;
+
+  inv_denom = _gamma1 * (*dudz + *dvdz);  // reuse
+  *dvdz = _gamma2 * (*dudz + *dvdz);
+  *dudz = inv_denom;
+
+  // Apply generalised projection matrix
+  // Matlab points start at 1
+  *u = _gamma1 * mx_u + _u0;
+  *v = _gamma2 * my_u + _v0;
+
+}
+
+/** 
+ * \brief Projects an undistorted 2D point (\a mx_u,\a my_u) to the image plane in (\a u,\a v)
+ *
+ * \param mx_u 2D point x coordinate
+ * \param my_u 3D point y coordinate
+ * \param u return value, contains the image point u coordinate
+ * \param v return value, contains the image point v coordinate
+ */
+void SphericalCameraGeometry::undist2plane(double mx_u, double my_u, double *u,
+                                           double *v) const {
+  //double mx_d, my_d;
+
+  /*
+   // Apply distortion
+   double dx_u, dy_u;
+   distortion(mx_u,my_u,&dx_u,&dy_u);
+   mx_d = mx_u+dx_u;
+   my_d = my_u+dy_u;
+   */
+
+  // Apply generalised projection matrix
+  // Matlab points start at 1
+  *u = _gamma1 * mx_u + _u0;
+  *v = _gamma2 * my_u + _v0;
+}
+
+void SphericalCameraGeometry::updateTemporaries() {
+  // Inverse camera projection matrix parameters
+  _inv_K11 = 1.0 / _gamma1;
+  _inv_K13 = -_u0 / _gamma1;
+  _inv_K22 = 1.0 / _gamma2;
+  _inv_K23 = -_v0 / _gamma2;
+  _one_over_xixi_m_1 = 1.0 / (_xi * _xi - 1.0);
+
+}
+
+void SphericalCameraGeometry::setIntrinsicsVectorImplementation(
+    const Eigen::VectorXd & V) {
+  _xi = V[0];
+  // MN: This offset (4 empty entries) is not nice, but provides a
+  // common interface with OmniCameras
+  _gamma1 = V[5];
+  _gamma2 = V[6];
+  _u0 = V[7];
+  _v0 = V[8];
+  updateTemporaries();
+
+}
+
+Eigen::VectorXd SphericalCameraGeometry::getIntrinsicsVectorImplementation() const {
+  Eigen::VectorXd V = Eigen::VectorXd::Zero(9);
+  V[0] = _xi;
+  // MN: This offset (4 empty entries) is not nice, but provides a
+  // common interface with OmniCameras
+  V[1] = 0;
+  V[2] = 0;
+  V[3] = 0;
+  V[4] = 0;
+  V[5] = _gamma1;
+  V[6] = _gamma2;
+  V[7] = _u0;
+  V[8] = _v0;
+  return V;
+}
+
+Eigen::Matrix3d SphericalCameraGeometry::getCameraMatrix() const {
+  Eigen::Matrix3d K;
+  K << _gamma1, 0, _u0, 0, _gamma2, _v0, 0, 0, 1;
+  return K;
+}
+
+Eigen::VectorXd SphericalCameraGeometry::createRandomKeypoint() const {
+  // This is tricky...The camera model defines a circle on the normalized image
+  // plane and the projection equations don't work outside of it.
+  // With some manipulation, we can see that, on the normalized image plane,
+  // the edge of this circle is at u^2 + v^2 = 1/(xi^2 - 1)
+  // So: this function creates keypoints inside this boundary.
+
+  // Create a point on the normalized image plane inside the boundary.
+  // This is not efficient, but it should be correct.
+
+  Eigen::Vector2d u(width() + 1, height() + 1);
+
+  while (u[0] < 0 || u[0] > width() - 1 || u[1] < 0 || u[1] > height() - 1) {
+    u.setRandom();
+    u = u - Eigen::Vector2d(0.5, 0.5);
+    u /= u.norm();
+    u *= ((double) rand() / (double) RAND_MAX) * _one_over_xixi_m_1;
+
+    /*
+     // Now we run the point through distortion and projection.
+     // Apply distortion
+     double dx_u, dy_u;
+     distortion(u[0],u[1],&dx_u,&dy_u);
+     double mx_d = u[0]+dx_u;
+     double my_d = u[1]+dy_u;
+     */
+
+    // Apply generalised projection matrix
+    // Matlab points start at 1
+    u[0] = _gamma1 * u[0] + _u0;
+    u[1] = _gamma2 * u[1] + _v0;
+  }
+
+  // I would like to do this below but it is way, way worse than above.
+  // // The output
+  // Eigen::Vector2d u;
+  // // The output projected to the normalized image plane.
+  // Eigen::Vector2d u_norm;
+
+  // // The singularity radius minus an epsilon
+  // double nRadius = 1.0/_one_over_xixi_m_1;
+
+  // do
+  // 	{
+  // 	  // Create a random keypoint in the image.
+  // 	  //u.setRandom();
+  // 	  u[0] = ( (double)rand() / (double)RAND_MAX)*_width;
+  // 	  u[1] = ( (double)rand() / (double)RAND_MAX)*_height;
+
+  // 	  // Lift points to normalised plane
+  // 	  // Matlab points start at 1 (calibration)
+  // 	  double u0_d = _inv_K11*(u[0])+_inv_K13;
+  // 	  double u1_d = _inv_K22*(u[1])+_inv_K23;
+  // 	  undistortGN(u0_d, u1_d, &u_norm[0], &u_norm[1]);
+
+  // 	}
+  // while( u_norm.dot(u_norm) >= nRadius );
+
+  return u;
+}
+
+}  // namespace cameras  
+
+}  // namespace aslam

--- a/deps/aslam_cameras/test/EquidistantDistortion.cpp
+++ b/deps/aslam_cameras/test/EquidistantDistortion.cpp
@@ -1,0 +1,24 @@
+// Bring in gtest
+#include <gtest/gtest.h>
+#include <sm/gtest.hpp>
+#include <aslam/cameras/FiniteDifferences.hpp>
+#include <aslam/cameras/EquidistantDistortion.hpp>
+#include "sm/assert_macros.hpp"
+
+TEST(AslamCamerasTestSuite, testEquiDistortion1)
+{
+  using namespace aslam::cameras;
+  EquidistantDistortion d(-0.00185, 0.01901, -0.02422, 0.01429);
+  Eigen::MatrixXd Jd, estJd;
+
+  Eigen::Vector2d x0(1.0E-1,1.0E-1);
+  Eigen::Vector2d x1(1.0E-1,1.0E-1);
+  d.distort(x1);
+  d.undistort(x1);
+  ASSERT_DOUBLE_MX_EQ(x0,x1,0.1,"");
+
+  Eigen::Vector2d x4(1.0E-1,1.0E-1);
+  d.distortParameterJacobian(x4,Jd);
+  ASLAM_CAMERAS_ESTIMATE_DISTORTION_JACOBIAN(distort, d, x4, 1e-3, estJd);
+  ASSERT_DOUBLE_MX_EQ(Jd,estJd,1.0,"");
+}

--- a/deps/aslam_cameras/test/FovDistortion.cpp
+++ b/deps/aslam_cameras/test/FovDistortion.cpp
@@ -1,0 +1,24 @@
+// Bring in gtest
+#include <gtest/gtest.h>
+#include <sm/gtest.hpp>
+#include <aslam/cameras/FiniteDifferences.hpp>
+#include <aslam/cameras/FovDistortion.hpp>
+#include <sm/assert_macros.hpp>
+
+TEST(AslamCamerasTestSuite, testFovDistortion1)
+{
+  using namespace aslam::cameras;
+  FovDistortion d(0.6);
+  Eigen::MatrixXd Jd, estJd;
+
+  Eigen::Vector2d x0(1.0E-1,1.0E-1);
+  Eigen::Vector2d x1(1.0E-1,1.0E-1);
+  d.distort(x1);
+  d.undistort(x1);
+  ASSERT_DOUBLE_MX_EQ(x0,x1,0.1,"");
+
+  Eigen::Vector2d x4(1.0E-1,1.0E-1);
+  d.distortParameterJacobian(x4,Jd);
+  ASLAM_CAMERAS_ESTIMATE_DISTORTION_JACOBIAN(distort, d, x4, 1e-3, estJd);
+  ASSERT_DOUBLE_MX_EQ(Jd,estJd,1.0,"");
+}

--- a/deps/aslam_cameras/test/OmniCameraGeometry.cpp
+++ b/deps/aslam_cameras/test/OmniCameraGeometry.cpp
@@ -1,0 +1,44 @@
+// Bring in gtest
+#include <gtest/gtest.h>
+#include <sm/gtest.hpp>
+#include <aslam/cameras.hpp>
+#include <aslam/cameras/test/CameraGeometryTestHarness.hpp>
+
+TEST(AslamCamerasTestSuite, testOmniCameraGeometry)
+{
+  using namespace aslam::cameras;
+  // Use a forgiving tolerance because of the approximate
+  // undistortion used in this model.
+  CameraGeometryTestHarness<OmniCameraGeometry> harness(0.1);
+
+  SCOPED_TRACE("omni camera");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testDistortedOmniCameraGeometryDefault)
+{
+  using namespace aslam::cameras;
+  // Use a forgiving tolerance because of the approximate
+  // undistortion used in this model.
+  CameraGeometryTestHarness<DistortedOmniCameraGeometry> harness(0.5);
+
+  SCOPED_TRACE("distorted omni default");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testDistortedOmniCameraGeometry)
+{
+  using namespace aslam::cameras;
+  // Use a forgiving tolerance because of the approximate
+  // undistortion used in this model.
+  RadialTangentialDistortion d(-0.2, 0.13, 0.0005, 0.0005);
+  DistortedOmniCameraGeometry geometry = DistortedOmniCameraGeometry::getTestGeometry();
+  geometry.projection().setDistortion(d);
+  CameraGeometryTestHarness<DistortedOmniCameraGeometry> harness(geometry,0.5);
+
+  SCOPED_TRACE("distorted omni");
+  harness.testAll();
+
+}

--- a/deps/aslam_cameras/test/PinholeCameraGeometry.cpp
+++ b/deps/aslam_cameras/test/PinholeCameraGeometry.cpp
@@ -1,0 +1,118 @@
+// Bring in gtest
+#include <gtest/gtest.h>
+#include <sm/gtest.hpp>
+#include <aslam/cameras.hpp>
+#include <aslam/cameras/test/CameraGeometryTestHarness.hpp>
+
+TEST(AslamCamerasTestSuite, testPinholeCameraGeometry)
+{
+  using namespace aslam::cameras;
+  CameraGeometryTestHarness<PinholeCameraGeometry> harness(1e-1);
+  SCOPED_TRACE("");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testDefaultDistortedPinholeCameraGeometry)
+{
+  using namespace aslam::cameras;
+  CameraGeometryTestHarness<DistortedPinholeCameraGeometry> harness(1e-1);
+  SCOPED_TRACE("");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testDistortedPinholeCameraGeometry)
+{
+  using namespace aslam::cameras;
+
+  RadialTangentialDistortion d(-0.2, 0.13, 0.0005, 0.0005);
+  DistortedPinholeCameraGeometry geometry = DistortedPinholeCameraGeometry::getTestGeometry();
+  geometry.projection().distortion() = d;
+
+  CameraGeometryTestHarness<DistortedPinholeCameraGeometry> harness(geometry, 1e-1);
+  SCOPED_TRACE("");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testPinholeRsCameraGeometry)
+{
+  using namespace aslam::cameras;
+  CameraGeometryTestHarness<PinholeRsCameraGeometry> harness(1e-1);
+  SCOPED_TRACE("");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testDefaultDistortedRsPinholeCameraGeometry)
+{
+  using namespace aslam::cameras;
+  CameraGeometryTestHarness<DistortedPinholeRsCameraGeometry> harness(2e-2);
+  SCOPED_TRACE("");
+  harness.testAll();
+
+}
+
+TEST(AslamCamerasTestSuite, testDistortedPinholeRsCameraGeometry)
+{
+  using namespace aslam::cameras;
+
+  RadialTangentialDistortion d(-0.2, 0.13, 0.0005, 0.0005);
+  DistortedPinholeRsCameraGeometry geometry = DistortedPinholeRsCameraGeometry::getTestGeometry();
+  geometry.projection().setDistortion(d);
+
+  CameraGeometryTestHarness<DistortedPinholeRsCameraGeometry> harness(geometry, 2e-2);
+  SCOPED_TRACE("");
+  harness.testAll();
+
+}
+
+// TEST(AslamCamerasTestSuite, testDistortedPinholeCameraGeometry) {
+
+//     std::cout << "pinholetest";
+
+//     // test distortion and distored jacobian:
+//     aslam::cameras::PinholeCameraGeometry pcg( aslam::cameras::PinholeCameraGeometry::createDistortedTestGeometry() );
+//     Eigen::Vector3d p = pcg.createRandomVisiblePoint();
+//     Eigen::Vector2d k = pcg.createRandomKeypoint();
+
+//     Eigen::MatrixXd J;
+//     Eigen::MatrixXd estJ;
+
+//     Eigen::Vector2d  k1 = pcg.euclideanToKeypoint(p);
+//     Eigen::Vector2d  k2 = pcg.euclideanToKeypoint(p, J);
+//     sm::eigen::assertEqual(k1,k2, SM_SOURCE_FILE_POS);
+//     pcg.euclideanToKeypointFiniteDifference(p,estJ);
+//     sm::eigen::assertNear(J,estJ, 1e-5, SM_SOURCE_FILE_POS);
+
+//     // Project to the normalized plane.
+//     double mx_u = p[0]/p[2];
+//     double my_u = p[1]/p[2];
+
+//     // Apply distortion.
+//     double mx_d, my_d;
+//     pcg.distortion(mx_u, my_u, &mx_d, &my_d);  
+//     // Distortion only puts out deltas.
+//     mx_d += mx_u;
+//     my_d += my_u;
+//     double hat_mx_u, hat_my_u;
+//     pcg.undistortGN(mx_d, my_d, &hat_mx_u, &hat_my_u) ;
+
+//     // Check if the error is small...
+//     double hat_mx_d, hat_my_d;
+//     pcg.distortion(hat_mx_u, hat_my_u, &hat_mx_d, &hat_my_d);  
+
+//     EXPECT_NEAR(hat_mx_u + hat_mx_d, mx_d, 1e-10);
+//     EXPECT_NEAR(hat_my_u + hat_my_d, my_d, 1e-10);
+
+//     double ax,bx,cx,dx;
+//     pcg.distortion(hat_mx_u, hat_my_u, &hat_mx_d, &hat_my_d, &ax, &bx, &cx, &dx);  
+
+//     EXPECT_NEAR(hat_mx_u + hat_mx_d, mx_d, 1e-10);
+//     EXPECT_NEAR(hat_my_u + hat_my_d, my_d, 1e-10);
+
+//     EXPECT_NEAR(hat_mx_u, mx_u, 1e-10);
+//     EXPECT_NEAR(hat_my_u, my_u, 1e-10);
+
+// }

--- a/deps/aslam_cameras/test/RadialTangentialDistortion.cpp
+++ b/deps/aslam_cameras/test/RadialTangentialDistortion.cpp
@@ -1,0 +1,24 @@
+// Bring in gtest
+#include <gtest/gtest.h>
+#include <sm/gtest.hpp>
+#include <aslam/cameras/FiniteDifferences.hpp>
+#include <aslam/cameras/RadialTangentialDistortion.hpp>
+#include <sm/assert_macros.hpp>
+
+TEST(AslamCamerasTestSuite, testRTDistortion1)
+{
+  using namespace aslam::cameras;
+  Eigen::Vector2d k(4e-3,4e-3);
+  Eigen::Vector2d kd = k;
+  Eigen::MatrixXd Jd, estJd;
+
+  RadialTangentialDistortion d(-0.2, 0.13, 0.0005, 0.0005);
+
+  d.distortParameterJacobian(kd,Jd);
+
+  ASLAM_CAMERAS_ESTIMATE_DISTORTION_JACOBIAN(distort, d, k, 1e-3, estJd);
+
+  d.distortParameterJacobian(kd,Jd);
+  ASSERT_DOUBLE_MX_EQ(Jd,estJd,1.0,"");
+
+}


### PR DESCRIPTION
Resolves #72 

Add camera models from kalibr's aslam_cv/aslam_cameras to deps/aslam_cameras

My process was to copy everything in aslam_cameras and remove things we don't need
that were non-trivial to compile. I had to add a few utility files that were in kalibr's sm ("Schweizer-Messer" == Swiss Army Knife) library. The goal was to keep the actual camera model functions mostly untouched, but not have to include all of kalibr as a dependency.

As such there may be some unneeded functions, but I don't know fully how much will be useful yet.

I removed everything related to:
- serialization
- calibration targets
- constructing from PropertyTree (confuguration object)
- landmarks, descriptors, and frames
- some versions of methods outputting uncertainty

I changed:
- custom `Duration` class in rolling shutter model to `std::chrono::duration` (it's not thoroughly tested, but we don't use this yet)

Testing: kalibr's unittests

I did not clang-format this code. I see it as a third-party inclusion (note **the way to `include` these headers from our other code is no different than if all of kalibr were installed as a dependency**). Keeping original formatting may help with things such as `diff`ing it against the original source.

**Pros**
- Fully featured camera models (pinhole, omni, distortions, with jacobians, etc)
- Took a day of work to add, instead of much longer
- No external dependency users must install

**Cons**
- "Original" BSD license with advertising clause
- Does not follow our formatting, style, or documentation standards
- We essentially maintain a fork of the dependency

#### Pre-Merge Checklist:
- [ ] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [ ] Formatted with `clang-format`
