### PR TITLE
FactorGraph: noise handling and priors

### DIFF
--- a/wave_optimization/CMakeLists.txt
+++ b/wave_optimization/CMakeLists.txt
@@ -19,7 +19,8 @@ WAVE_ADD_TEST(${PROJECT_NAME}_tests
               tests/ceres/ceres_examples_test.cpp
               tests/factor_graph/factor_test.cpp
               tests/factor_graph/graph_test.cpp
-              tests/factor_graph/variable_test.cpp)
+              tests/factor_graph/variable_test.cpp
+              tests/factor_graph/noise_test.cpp)
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}_tests
                       ${PROJECT_NAME}
                       wave_utils

--- a/wave_optimization/include/wave/optimization/ceres/graph_wrapper.hpp
+++ b/wave_optimization/include/wave/optimization/ceres/graph_wrapper.hpp
@@ -31,15 +31,17 @@ void addFactorToProblem(ceres::Problem &problem, FactorBase &factor) {
         // @todo can add local parametrization in this call
         problem.AddParameterBlock(v->data(), v->size());
 
-        // Set parameter blocks constant if the variable is so marked
-        if (v->isFixed()) {
+        // Set parameter blocks constant if the factor is a zero-noise prior
+        if (factor.isPerfectPrior()) {
             problem.SetParameterBlockConstant(v->data());
         }
     }
 
     // Give ceres the cost function and its parameter blocks.
-    problem.AddResidualBlock(
-      factor.costFunction().release(), nullptr, data_ptrs);
+    if (!factor.isPerfectPrior()) {
+        problem.AddResidualBlock(
+          factor.costFunction().release(), nullptr, data_ptrs);
+    }
 }
 
 /**

--- a/wave_optimization/include/wave/optimization/ceres/graph_wrapper.hpp
+++ b/wave_optimization/include/wave/optimization/ceres/graph_wrapper.hpp
@@ -17,13 +17,37 @@ namespace wave {
 /** @addtogroup optimization
  *  @{ */
 
-void addFactorToProblem(ceres::Problem &problem, FactorBase &factor) {
+/**
+ * Ceres cost function wrapping `Factor::evaluateRaw`.
+ */
+class FactorCostFunction : public ceres::CostFunction {
+ public:
+    explicit FactorCostFunction(std::shared_ptr<FactorBase> factor)
+        : factor{factor} {
+        this->set_num_residuals(factor->residualSize());
+        for (const auto &var : factor->variables()) {
+            this->mutable_parameter_block_sizes()->push_back(var->size());
+        }
+    }
+
+    bool Evaluate(double const *const *parameters,
+                  double *residuals,
+                  double **jacobians) const override {
+        return factor->evaluateRaw(parameters, residuals, jacobians);
+    }
+
+ private:
+    std::shared_ptr<FactorBase> factor;
+};
+
+void addFactorToProblem(ceres::Problem &problem,
+                        std::shared_ptr<FactorBase> factor) {
     // We make a vector of residual block pointers and pass it to
     // AddResidualBlock because Ceres' implementation forms a vector
     // anyway.
     auto data_ptrs = std::vector<double *>{};
 
-    for (const auto &v : factor.variables()) {
+    for (const auto &v : factor->variables()) {
         data_ptrs.push_back(v->data());
 
         // Explicitly adding parameters "causes additional correctness
@@ -32,15 +56,15 @@ void addFactorToProblem(ceres::Problem &problem, FactorBase &factor) {
         problem.AddParameterBlock(v->data(), v->size());
 
         // Set parameter blocks constant if the factor is a zero-noise prior
-        if (factor.isPerfectPrior()) {
+        if (factor->isPerfectPrior()) {
             problem.SetParameterBlockConstant(v->data());
         }
     }
 
-    // Give ceres the cost function and its parameter blocks.
-    if (!factor.isPerfectPrior()) {
+    // Finally, give ceres the cost function and its parameter blocks.
+    if (!factor->isPerfectPrior()) {
         problem.AddResidualBlock(
-          factor.costFunction().release(), nullptr, data_ptrs);
+          new FactorCostFunction{std::move(factor)}, nullptr, data_ptrs);
     }
 }
 
@@ -54,7 +78,7 @@ void evaluateGraph(FactorGraph &graph) {
     ceres::Problem problem;
 
     for (const auto &ptr : graph) {
-        addFactorToProblem(problem, *ptr);
+        addFactorToProblem(problem, ptr);
     }
 
     // Initialize the solver

--- a/wave_optimization/include/wave/optimization/factor_graph/Factor.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/Factor.hpp
@@ -98,12 +98,9 @@ class Factor : public FactorBase {
     using const_iterator = typename VarArrayType::const_iterator;
 
     /** Construct with the given function, measurement and variables. */
-    explicit Factor(FuncType f,
-                    MeasType meas,
-                    std::shared_ptr<VarTypes>... variable_ptrs)
-        : measurement_function{f},
-          measurement{meas},
-          variable_ptrs{{variable_ptrs...}} {}
+    explicit Factor(FuncType measurement_function,
+                    MeasType measurement,
+                    std::shared_ptr<VarTypes>... variable_ptrs);
 
     ~Factor() override = default;
 
@@ -121,8 +118,7 @@ class Factor : public FactorBase {
                             std::placeholders::_2,
                             std::placeholders::_3);
         return std::unique_ptr<ceres::CostFunction>{
-          new FactorCostFunction<ResidualSize, VarTypes::ViewType::Size...>{
-            fn}};
+          new FactorCostFunction<ResidualSize, VarTypes::Size...>{fn}};
     }
 
     bool evaluateRaw(double const *const *parameters,
@@ -139,6 +135,12 @@ class Factor : public FactorBase {
     void print(std::ostream &os) const override;
 
  private:
+    /** Set each variable fixed
+     * @throw std::runtime_error if one is already fixed
+     */
+    void setVariablesFixed();
+
+
     FuncType *measurement_function;
 
     /** Storage of the measurement */
@@ -153,4 +155,4 @@ class Factor : public FactorBase {
 
 #include "impl/Factor.hpp"
 
-#endif
+#endif  // WAVE_OPTIMIZATION_FACTOR_GRAPH_PERFECT_PRIOR_HPP

--- a/wave_optimization/include/wave/optimization/factor_graph/Factor.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/Factor.hpp
@@ -140,7 +140,6 @@ class Factor : public FactorBase {
      */
     void setVariablesFixed();
 
-
     FuncType *measurement_function;
 
     /** Storage of the measurement */

--- a/wave_optimization/include/wave/optimization/factor_graph/Factor.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/Factor.hpp
@@ -6,14 +6,10 @@
 #ifndef WAVE_OPTIMIZATION_FACTOR_GRAPH_FACTOR_HPP
 #define WAVE_OPTIMIZATION_FACTOR_GRAPH_FACTOR_HPP
 
-#include <ceres/sized_cost_function.h>
-#include <memory>
-
 #include "wave/utils/math.hpp"
 #include "wave/optimization/factor_graph/FactorVariableBase.hpp"
 #include "wave/optimization/factor_graph/FactorBase.hpp"
 #include "wave/optimization/factor_graph/OutputMap.hpp"
-#include "wave/optimization/factor_graph/FactorMeasurement.hpp"
 
 
 namespace wave {
@@ -86,8 +82,6 @@ class Factor : public FactorBase {
                     MeasType measurement,
                     std::shared_ptr<VarTypes>... variable_ptrs);
 
-    ~Factor() override = default;
-
     int size() const override {
         return NumVars;
     }
@@ -123,66 +117,9 @@ class Factor : public FactorBase {
     VarArrayType variable_ptrs;
 };
 
-template <typename VarType>
-class PerfectPrior : public FactorBase {
-    using FactorType = PerfectPrior<VarType>;
-    using ViewType = typename VarType::ViewType;
-    using MeasType = FactorMeasurement<ViewType, void>;
-
- public:
-    constexpr static int NumVars = 1;
-    constexpr static int ResidualSize = MeasType::Size;
-    using ResidualType = Eigen::Matrix<double, ResidualSize, 1>;
-    using VarArrayType = FactorBase::VarVectorType;
-    using const_iterator = typename VarArrayType::const_iterator;
-
-    /** Construct with the given measurement and variable. */
-    explicit PerfectPrior(MeasType measurement,
-                          std::shared_ptr<VarType> variable_ptr)
-        : measurement{measurement}, variable_ptrs{variable_ptr} {
-        // Assign to the variable
-        variable_ptr->value.asVector() = measurement.value.asVector();
-    }
-
-    ~PerfectPrior() override = default;
-
-    int size() const override {
-        return NumVars;
-    }
-
-    int residualSize() const override {
-        return ResidualSize;
-    }
-
-    bool evaluateRaw(double const *const *, double *, double **) const
-      noexcept override {
-        return false;
-    }
-
-    /** Get a reference to the vector of variable pointers */
-    const VarVectorType &variables() const noexcept override {
-        return this->variable_ptrs;
-    }
-
-    /** Return true if this factor is a zero-noise prior */
-    bool isPerfectPrior() const noexcept override {
-        return true;
-    }
-
-    /** Print a representation for debugging. Used by operator<< */
-    void print(std::ostream &os) const override {}
-
- private:
-    /** Storage of the measurement */
-    MeasType measurement;
-
-    /** Pointers to the variables this factor is linked to */
-    VarArrayType variable_ptrs;
-};
-
 /** @} group optimization */
 }  // namespace wave
 
 #include "impl/Factor.hpp"
 
-#endif  // WAVE_OPTIMIZATION_FACTOR_GRAPH_PERFECT_PRIOR_HPP
+#endif  // WAVE_OPTIMIZATION_FACTOR_GRAPH_FACTOR_HPP

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorBase.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorBase.hpp
@@ -50,6 +50,9 @@ class FactorBase {
 
     /** Get a reference to the vector of variable pointers */
     virtual const VarVectorType &variables() const noexcept = 0;
+
+    /** Return true if this factor is a zero-noise prior */
+    virtual bool isPerfectPrior() const noexcept = 0;
 };
 
 

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorBase.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorBase.hpp
@@ -44,9 +44,11 @@ class FactorBase {
      * Called by `operator<<`. */
     virtual void print(std::ostream &os) const = 0;
 
+    /** The arity (number of variables connected) of the factor */
     virtual int size() const = 0;
-    virtual int numResiduals() const = 0;
-    virtual std::unique_ptr<ceres::CostFunction> costFunction() = 0;
+
+    /** The dimension of the measurement and residual vector */
+    virtual int residualSize() const = 0;
 
     /** Get a reference to the vector of variable pointers */
     virtual const VarVectorType &variables() const noexcept = 0;

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorGraph.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorGraph.hpp
@@ -53,8 +53,12 @@ class FactorGraph {
      */
     template <typename FuncType, typename MeasType, typename... VarTypes>
     void addFactor(FuncType f,
-                   const MeasType &meas,
+                   const MeasType &measurement,
                    std::shared_ptr<VarTypes>... variables);
+
+    template <typename MeasType>
+    void addPrior(const MeasType &measurement,
+                  std::shared_ptr<typename MeasType::VarType> variable);
 
     // Iterators
 

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorGraph.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorGraph.hpp
@@ -60,6 +60,10 @@ class FactorGraph {
     void addPrior(const MeasType &measurement,
                   std::shared_ptr<typename MeasType::VarType> variable);
 
+    template <typename VarType>
+    void addPerfectPrior(const typename VarType::MappedType &measured_value,
+                         std::shared_ptr<VarType> variable);
+
     // Iterators
 
     /** Return iterator over factors */

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
@@ -7,48 +7,91 @@
 #define WAVE_OPTIMIZATION_FACTOR_GRAPH_MEASUREMENT_HPP
 
 #include "wave/optimization/factor_graph/FactorVariable.hpp"
-
+#include "wave/optimization/factor_graph/Noise.hpp"
 
 namespace wave {
 /** @addtogroup optimization
  *  @{ */
 
-/**
- * A measurement associated with a Factor
- *
- * @tparam V the type of ValueView representing the measurement's value
- * @todo a Noise parameter will be added here
- */
+/** The default NoiseType parameter to FactorMeasurement */
 template <typename V>
+using DefaultNoiseType = DiagonalNoise<FactorVariable<V>::Size>;
+
+/**
+ * A measurement, with associated noise, associated with a Factor
+ * @tparam V the type of ValueView representing the measurement's value
+ * @tparam NoiseTmpl the type of noise
+ */
+template <typename V, typename N = DefaultNoiseType<V>>
 class FactorMeasurement : public FactorVariable<V> {
     using Base = FactorVariable<V>;
 
  public:
+    using VarType = Base;
     using ViewType = typename Base::ViewType;
+    using NoiseType = N;
+    using MappedType = typename Base::MappedType;
+    constexpr static int Size = Base::Size;
+
+    /** Construct with initial value and initial noise value*/
+    explicit FactorMeasurement(MappedType &&initial,
+                               typename NoiseType::InitType &&noise)
+        : Base{std::move(initial)}, noise{std::move(noise)} {}
+
+    /** Construct copying initial value and initial noise value*/
+    explicit FactorMeasurement(const MappedType &initial,
+                               const typename NoiseType::InitType &noise)
+        : Base{initial}, noise{noise} {}
+
+    /** Construct with initial value and initial noise value*/
+    explicit FactorMeasurement(MappedType &&initial, NoiseType &&noise)
+        : Base{std::move(initial)}, noise{std::move(noise)} {}
+
+    /** Construct copying initial value and initial noise value*/
+    explicit FactorMeasurement(const MappedType &initial,
+                               const NoiseType &noise)
+        : Base{initial}, noise{noise} {}
+
+    NoiseType noise;
+};
+
+/**
+ * Partially specialized FactorMeasurement with zero noise
+ */
+template <typename V>
+class FactorMeasurement<V, ZeroNoise> : public FactorVariable<V> {
+    using Base = FactorVariable<V>;
+
+ public:
+    using ViewType = typename Base::ViewType;
+    using NoiseType = ZeroNoise;
     using MappedType = typename Base::MappedType;
     constexpr static int Size = Base::Size;
 
     /** Construct with initial value */
     explicit FactorMeasurement(MappedType &&initial)
-        : Base{std::move(initial)} {}
+        : Base{std::move(initial)} {
+        this->setFixed(true);
+    }
 
     /** Construct copying initial value  */
     explicit FactorMeasurement(const MappedType &initial) : Base{initial} {}
+
+    ZeroNoise noise;
 };
 
-/** Subtract a measurement from the result of a measurement function
- * @return the difference: the non-normalized residual
- */
-template <typename V>
-inline Eigen::Matrix<double, 1, FactorMeasurement<V>::Size> operator-(
-  const ResultOut<FactorMeasurement<V>::Size> &lhs,
-  const FactorMeasurement<V> &rhs) {
-    // We need to accept the specific types and manually convert them, as Eigen
-    // 3.2 is not as great at automatically converting things. See #151
-    return lhs - Eigen::Map<
-                   const Eigen::Matrix<double, 1, FactorMeasurement<V>::Size>>{
-                   rhs.data()};
+
+template <typename V, typename N>
+inline Eigen::Matrix<double, 1, FactorMeasurement<V, N>::Size> operator-(
+  const Eigen::Ref<Eigen::Matrix<double, 1, FactorMeasurement<V, N>::Size>>
+    &lhs,
+  const FactorMeasurement<V, N> &rhs) {
+    return lhs -
+           Eigen::Map<
+             const Eigen::Matrix<double, 1, FactorMeasurement<V, N>::Size>>{
+             rhs.data()};
 }
+
 
 /** @} group optimization */
 }  // namespace wave

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
@@ -34,52 +34,46 @@ class FactorMeasurement : public FactorVariable<V> {
     constexpr static int Size = Base::Size;
 
     /** Construct with initial value and initial noise value*/
-    explicit FactorMeasurement(MappedType &&initial,
-                               typename NoiseType::InitType &&noise)
+    explicit FactorMeasurement(MappedType initial,
+                               typename NoiseType::InitType noise_value)
+        : Base{std::move(initial)}, noise{std::move(noise_value)} {}
+
+
+    /** Construct with initial value and initial noise object*/
+    explicit FactorMeasurement(MappedType initial, NoiseType noise)
         : Base{std::move(initial)}, noise{std::move(noise)} {}
 
-    /** Construct copying initial value and initial noise value*/
-    explicit FactorMeasurement(const MappedType &initial,
-                               const typename NoiseType::InitType &noise)
-        : Base{initial}, noise{noise} {}
-
-    /** Construct with initial value and initial noise value*/
-    explicit FactorMeasurement(MappedType &&initial, NoiseType &&noise)
-        : Base{std::move(initial)}, noise{std::move(noise)} {}
-
-    /** Construct copying initial value and initial noise value*/
-    explicit FactorMeasurement(const MappedType &initial,
-                               const NoiseType &noise)
-        : Base{initial}, noise{noise} {}
+    /** Construct with initial value and no noise
+     * Only allowed when NoiseType is void*/
+    explicit FactorMeasurement(MappedType initial) : Base{std::move(initial)} {
+        static_assert(std::is_void<NoiseType>::value,
+                      "A noise value must be provided as the second argument");
+    }
 
     NoiseType noise;
 };
 
+
 /**
  * Partially specialized FactorMeasurement with zero noise
+ *
+ * This specialization can be constructed with a measured value only, without
+ * needing to specify noise.
  */
 template <typename V>
-class FactorMeasurement<V, ZeroNoise> : public FactorVariable<V> {
+class FactorMeasurement<V, void> : public FactorVariable<V> {
     using Base = FactorVariable<V>;
 
  public:
+    using VarType = Base;
     using ViewType = typename Base::ViewType;
-    using NoiseType = ZeroNoise;
+    using NoiseType = void;
     using MappedType = typename Base::MappedType;
     constexpr static int Size = Base::Size;
 
-    /** Construct with initial value */
-    explicit FactorMeasurement(MappedType &&initial)
-        : Base{std::move(initial)} {
-        this->setFixed(true);
-    }
-
-    /** Construct copying initial value  */
-    explicit FactorMeasurement(const MappedType &initial) : Base{initial} {}
-
-    ZeroNoise noise;
+    /** Construct with initial value and no noise */
+    explicit FactorMeasurement(MappedType initial) : Base{std::move(initial)} {}
 };
-
 
 template <typename V, typename N>
 inline Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1> operator-(

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
@@ -8,6 +8,7 @@
 
 #include "wave/optimization/factor_graph/FactorVariable.hpp"
 #include "wave/optimization/factor_graph/Noise.hpp"
+#include "wave/optimization/factor_graph/OutputMap.hpp"
 
 namespace wave {
 /** @addtogroup optimization
@@ -77,9 +78,10 @@ class FactorMeasurement<V, void> : public FactorVariable<V> {
 
 template <typename V, typename N>
 inline Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1> operator-(
-  const Eigen::Ref<Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1>>
-    &lhs,
+  const ResultOut<FactorMeasurement<V, N>::Size> &lhs,
   const FactorMeasurement<V, N> &rhs) {
+    // We need to accept the specific ResultOut type (instead of a generic Eigen
+    // map) as for some reason they are not converted with Eigen 3.2. See #151
     return lhs -
            Eigen::Map<
              const Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1>>{

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorMeasurement.hpp
@@ -82,13 +82,13 @@ class FactorMeasurement<V, ZeroNoise> : public FactorVariable<V> {
 
 
 template <typename V, typename N>
-inline Eigen::Matrix<double, 1, FactorMeasurement<V, N>::Size> operator-(
-  const Eigen::Ref<Eigen::Matrix<double, 1, FactorMeasurement<V, N>::Size>>
+inline Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1> operator-(
+  const Eigen::Ref<Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1>>
     &lhs,
   const FactorMeasurement<V, N> &rhs) {
     return lhs -
            Eigen::Map<
-             const Eigen::Matrix<double, 1, FactorMeasurement<V, N>::Size>>{
+             const Eigen::Matrix<double, FactorMeasurement<V, N>::Size, 1>>{
              rhs.data()};
 }
 

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorVariable.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorVariable.hpp
@@ -57,18 +57,11 @@ class FactorVariable : public FactorVariableBase {
     FactorVariable() noexcept : storage{MappedType::Zero()}, value{storage} {}
 
     /** Construct with initial value */
-    explicit FactorVariable(MappedType &&initial) noexcept
-      : storage{std::move(initial)},
-        value{storage} {}
-
-    /** Construct copying initial value */
-    explicit FactorVariable(const MappedType &initial) noexcept
-      : storage{initial},
-        value{storage} {}
+    explicit FactorVariable(MappedType initial)
+        : storage{std::move(initial)}, value{storage} {}
 
     // Because `value` is a map holding a pointer to another member, we must
     // define a custom copy constructor (and the rest of the rule of five)
-
     /** Copy constructor */
     FactorVariable(const FactorVariable &other) noexcept
       : FactorVariable{other.storage} {}
@@ -99,7 +92,6 @@ class FactorVariable : public FactorVariableBase {
     ~FactorVariable() override = default;
 
     // Access
-
 
     /** Return the number of scalar values in the variable. */
     int size() const noexcept override {

--- a/wave_optimization/include/wave/optimization/factor_graph/FactorVariableBase.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/FactorVariableBase.hpp
@@ -22,26 +22,9 @@ class FactorVariableBase {
     virtual const double *data() const noexcept = 0;
     virtual double *data() noexcept = 0;
 
-    /** Marks as constant during optimization
-     * @todo replace with unary factors for priors
-     */
-    void setFixed(bool c) noexcept {
-        this->fixed = c;
-    }
-
-    /** Whether this has been marked constant during optimization
-     * @todo replace with unary factors for priors
-     */
-    bool isFixed() const noexcept {
-        return this->fixed;
-    }
-
     /** Print representation of the object for debugging.
      * Called by `operator<<`. */
     virtual void print(std::ostream &os) const = 0;
-
- private:
-    bool fixed = false;
 };
 
 inline std::ostream &operator<<(std::ostream &os, const FactorVariableBase &v) {

--- a/wave_optimization/include/wave/optimization/factor_graph/Noise.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/Noise.hpp
@@ -92,8 +92,23 @@ class DiagonalNoise<1> {
 
 /**
  * Struct representing the special case of zero noise.
+ *
+ * Its member functions always throw, and are not expected to be called. Any
+ * measurements attached to factors with a ZeroNoise measurement are marked
+ * constant, and should never be evaluated by the optimizer.
+ *
+ * @todo make sure this assumption holds up
  */
-class ZeroNoise {};
+class ZeroNoise {
+ public:
+    double inverseSqrtCov() const {
+        throw std::logic_error("Special ZeroNoise type has no covariance");
+    }
+
+    double covariance() const {
+        throw std::logic_error("Special ZeroNoise type has no covariance");
+    };
+};
 
 
 /** @} group optimization */

--- a/wave_optimization/include/wave/optimization/factor_graph/Noise.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/Noise.hpp
@@ -1,0 +1,102 @@
+/**
+ * @file
+ * @ingroup optimization
+ */
+
+#ifndef WAVE_OPTIMIZATION_FACTOR_GRAPH_NOISE_HPP
+#define WAVE_OPTIMIZATION_FACTOR_GRAPH_NOISE_HPP
+
+#include <iostream>
+
+#include "wave/utils/math.hpp"
+#include "wave/optimization/factor_graph/FactorVariableBase.hpp"
+
+namespace wave {
+/** @addtogroup optimization
+ *  @{ */
+
+template <typename T>
+struct traits {};
+
+/**
+ * Gaussian noise with full covariance matrix
+ * @tparam S dimension of the value
+ */
+template <int S>
+class FullNoise {
+ public:
+    explicit FullNoise(Eigen::Matrix<double, S, S> cov) : covariance_mat{cov} {}
+
+    Eigen::Matrix<double, S, S> inverseSqrtCov() const {
+        const auto L =
+          Eigen::Matrix<double, S, S>{this->covariance_mat.llt().matrixL()};
+        return L.inverse();
+    };
+
+    Eigen::Matrix<double, S, S> covariance() const {
+        return this->covariance_mat;
+    };
+
+ private:
+    Eigen::Matrix<double, S, S> covariance_mat;
+};
+
+/**
+ * Gaussian noise with diagonal covariance matrix
+ * @tparam S dimension of the value
+ */
+template <int S>
+class DiagonalNoise {
+ public:
+    // Decide which type must be passed in the constructor
+    // Normally it's an Eigen vector, but for size-one values accept a double.
+    using InitType = Eigen::Matrix<double, S, 1>;
+
+    explicit DiagonalNoise(const InitType &sigma)
+        : covariance_mat{sigma.cwiseProduct(sigma)} {}
+
+    Eigen::DiagonalMatrix<double, S> inverseSqrtCov() const {
+        return Eigen::DiagonalMatrix<double, S>{
+          this->covariance_mat.diagonal().cwiseSqrt().cwiseInverse()};
+    };
+
+    Eigen::DiagonalMatrix<double, S> covariance() const {
+        return this->covariance_mat;
+    };
+
+ private:
+    Eigen::DiagonalMatrix<double, S> covariance_mat;
+};
+
+/**
+ * Special case of noise for a single value
+ */
+template <>
+class DiagonalNoise<1> {
+ public:
+    using InitType = double;
+
+    explicit DiagonalNoise<1>(double stddev) : stddev{stddev} {}
+
+    double inverseSqrtCov() const {
+        return 1. / this->stddev;
+    }
+
+    double covariance() const {
+        return this->stddev * this->stddev;
+    };
+
+ private:
+    double stddev;
+};
+
+/**
+ * Struct representing the special case of zero noise.
+ */
+class ZeroNoise {};
+
+
+/** @} group optimization */
+}  // namespace wave
+
+#endif  // WAVE_OPTIMIZATION_FACTOR_GRAPH_NOISE_HPP

--- a/wave_optimization/include/wave/optimization/factor_graph/Noise.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/Noise.hpp
@@ -90,27 +90,6 @@ class DiagonalNoise<1> {
     double stddev;
 };
 
-/**
- * Struct representing the special case of zero noise.
- *
- * Its member functions always throw, and are not expected to be called. Any
- * measurements attached to factors with a ZeroNoise measurement are marked
- * constant, and should never be evaluated by the optimizer.
- *
- * @todo make sure this assumption holds up
- */
-class ZeroNoise {
- public:
-    double inverseSqrtCov() const {
-        throw std::logic_error("Special ZeroNoise type has no covariance");
-    }
-
-    double covariance() const {
-        throw std::logic_error("Special ZeroNoise type has no covariance");
-    };
-};
-
-
 /** @} group optimization */
 }  // namespace wave
 

--- a/wave_optimization/include/wave/optimization/factor_graph/OutputMap.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/OutputMap.hpp
@@ -29,11 +29,37 @@ class OutputMap : public Eigen::Map<T> {
         return this->data() != nullptr;
     }
 
+    /* Assign from an Eigen matrix */
     template <typename OtherDerived>
     OutputMap &operator=(const Eigen::MatrixBase<OtherDerived> &other) {
         this->Eigen::Map<T>::operator=(other);
         return *this;
     }
+
+    /**
+     * Assign from a ValueView
+     *
+     * @tparam ViewType the type of ValueView
+     * @tparam MappedType specified only so this template is used only for
+     * ValueView types (see SFINAE)
+     */
+    template <typename ViewType,
+              typename MappedType = typename ViewType::MappedType>
+    OutputMap &operator=(const ViewType &v) {
+        this->Eigen::Map<T>::operator=(Eigen::Map<const MappedType>{v.data()});
+        return *this;
+    }
+
+    /**
+     * Assign from a double
+     * Allowed for values of size 1 only
+     */
+    OutputMap &operator=(double v) {
+        static_assert(OutputMap::SizeAtCompileTime == 1,
+                      "Only OutputMap of size 1 may be assigned doubles");
+        *this->data() = v;
+        return *this;
+    };
 };
 
 /** Type of jacobian output parameters for `Factor::evaluate()`. */

--- a/wave_optimization/include/wave/optimization/factor_graph/OutputMap.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/OutputMap.hpp
@@ -46,7 +46,7 @@ class OutputMap : public Eigen::Map<T> {
     template <typename ViewType,
               typename MappedType = typename ViewType::MappedType>
     OutputMap &operator=(const ViewType &v) {
-        this->Eigen::Map<T>::operator=(Eigen::Map<const MappedType>{v.data()});
+        this->Eigen::Map<T>::operator=(v.asVector());
         return *this;
     }
 

--- a/wave_optimization/include/wave/optimization/factor_graph/PerfectPrior.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/PerfectPrior.hpp
@@ -79,7 +79,11 @@ class PerfectPrior : public FactorBase {
     }
 
     /** Print a representation for debugging. Used by operator<< */
-    void print(std::ostream &os) const override {}
+    void print(std::ostream &os) const override {
+        os << "[Perfect prior for variable ";
+        const auto &v = this->variable_ptrs.front();
+        os << *v << "(" << v << ")]";
+    }
 
  private:
     /** Storage of the measurement */

--- a/wave_optimization/include/wave/optimization/factor_graph/PerfectPrior.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/PerfectPrior.hpp
@@ -1,0 +1,95 @@
+/**
+ * @file
+ * @ingroup optimization
+ */
+
+#ifndef WAVE_OPTIMIZATION_FACTOR_GRAPH_PERFECT_PRIOR_HPP
+#define WAVE_OPTIMIZATION_FACTOR_GRAPH_PERFECT_PRIOR_HPP
+
+#include "wave/optimization/factor_graph/FactorVariableBase.hpp"
+#include "wave/optimization/factor_graph/FactorBase.hpp"
+#include "wave/optimization/factor_graph/FactorMeasurement.hpp"
+
+
+namespace wave {
+/** @addtogroup optimization
+ *  @{ */
+
+/**
+ * A unary factor representing a noiseless prior
+ *
+ * A prior in a factor graph can be described as
+ *
+ * @f[
+ * Z = f(\theta) + \epsilon
+ * @f]
+ *
+ * where @f$ f @$f is the measurement function,  @f$ \theta @$f is a random
+ * variable and @f$ \epsilon @$f is random noise. @f$ \epsilon @f cannot be
+ * zero in general, as there may not be a solution for @f$ \Theta @$f.
+ *
+ * In libwave, noiseless priors are allowed in the case of a direct
+ * measurement (i.e., @f$ f(\theta) = \theta @$f). These are called perfect
+ * priors. Each FactorVariable may be connected to at most one perfect prior.
+ *
+ * @tparam VarType The type of factor variable we have prior information on
+ */
+template <typename VarType>
+class PerfectPrior : public FactorBase {
+    using FactorType = PerfectPrior<VarType>;
+    using ViewType = typename VarType::ViewType;
+    using MeasType = FactorMeasurement<ViewType, void>;
+
+ public:
+    constexpr static int NumVars = 1;
+    constexpr static int ResidualSize = MeasType::Size;
+    using ResidualType = Eigen::Matrix<double, ResidualSize, 1>;
+    using VarArrayType = FactorBase::VarVectorType;
+    using const_iterator = typename VarArrayType::const_iterator;
+
+    /** Construct with the given measurement and variable. */
+    explicit PerfectPrior(MeasType measurement,
+                          std::shared_ptr<VarType> variable_ptr)
+        : measurement{measurement}, variable_ptrs{variable_ptr} {
+        // Assign to the variable
+        variable_ptr->value = measurement.value;
+    }
+
+    int size() const override {
+        return NumVars;
+    }
+
+    int residualSize() const override {
+        return ResidualSize;
+    }
+
+    bool evaluateRaw(double const *const *, double *, double **) const
+      noexcept override {
+        return false;
+    }
+
+    /** Get a reference to the vector of variable pointers */
+    const VarVectorType &variables() const noexcept override {
+        return this->variable_ptrs;
+    }
+
+    /** Return true if this factor is a zero-noise prior */
+    bool isPerfectPrior() const noexcept override {
+        return true;
+    }
+
+    /** Print a representation for debugging. Used by operator<< */
+    void print(std::ostream &os) const override {}
+
+ private:
+    /** Storage of the measurement */
+    MeasType measurement;
+
+    /** Pointers to the variables this factor is linked to */
+    VarArrayType variable_ptrs;
+};
+
+/** @} group optimization */
+}  // namespace wave
+
+#endif  // WAVE_OPTIMIZATION_FACTOR_GRAPH_PERFECT_PRIOR_HPP

--- a/wave_optimization/include/wave/optimization/factor_graph/ValueView.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/ValueView.hpp
@@ -55,6 +55,16 @@ class ValueView {
         return Size;
     }
 
+    /** Return an Eigen Map to the data */
+    Eigen::Map<const MappedType> asVector() const {
+        return Eigen::Map<const MappedType>{this->dataptr};
+    }
+
+    /** Return an Eigen Map to the data */
+    Eigen::Map<MappedType> asVector() {
+        return Eigen::Map<MappedType>{this->dataptr};
+    }
+
     /** Return a raw pointer to the start of the internal vector */
     const double *data() const {
         return this->dataptr;

--- a/wave_optimization/include/wave/optimization/factor_graph/ValueView.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/ValueView.hpp
@@ -50,6 +50,12 @@ class ValueView {
     /** Construct to map the given mapped Eigen matrix */
     explicit ValueView(MappedType &m) : dataptr{m.data()} {}
 
+    /** Copy the value of another ValueView */
+    ValueView &operator=(const ValueView<S> &other) {
+        this->asVector() = other.asVector();
+        return *this;
+    }
+
     /** Return the size of the underlying value */
     constexpr int size() const noexcept {
         return Size;

--- a/wave_optimization/include/wave/optimization/factor_graph/impl/Factor.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/impl/Factor.hpp
@@ -141,7 +141,9 @@ bool Factor<M, V...>::evaluateRaw(double const *const *parameters,
       internal::make_index_sequence<sizeof...(V)>());
 
     if (ok) {
-        results = results - this->measurement;
+        // Calculate the normalized residual
+        const auto &L = this->measurement.noise.inverseSqrtCov();
+        results = L * (results - this->measurement);
     }
     return ok;
 }

--- a/wave_optimization/include/wave/optimization/factor_graph/impl/FactorGraph.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/impl/FactorGraph.hpp
@@ -1,3 +1,5 @@
+#include "wave/optimization/factor_graph/FactorMeasurement.hpp"
+
 namespace wave {
 
 namespace internal {
@@ -59,6 +61,16 @@ inline void FactorGraph::addPrior(
       internal::identityMeasurementFunction<typename MeasType::ViewType>,
       measurement,
       std::move(variable));
+}
+
+template <typename VarType>
+inline void FactorGraph::addPerfectPrior(
+  const typename VarType::MappedType &measured_value,
+  std::shared_ptr<VarType> variable) {
+    using MeasType = FactorMeasurement<typename VarType::ViewType, void>;
+
+    this->factors.emplace_back(std::make_shared<PerfectPrior<VarType>>(
+      MeasType{measured_value}, std::move(variable)));
 }
 
 // Iterators

--- a/wave_optimization/include/wave/optimization/factor_graph/impl/FactorGraph.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/impl/FactorGraph.hpp
@@ -1,4 +1,5 @@
 #include "wave/optimization/factor_graph/FactorMeasurement.hpp"
+#include "wave/optimization/factor_graph/PerfectPrior.hpp"
 
 namespace wave {
 

--- a/wave_optimization/include/wave/optimization/factor_graph/impl/FactorGraph.hpp
+++ b/wave_optimization/include/wave/optimization/factor_graph/impl/FactorGraph.hpp
@@ -1,23 +1,45 @@
 namespace wave {
 
+namespace internal {
+
+/**
+ * Trivial measurement function for a prior, f(X) = X
+ */
+template <typename V>
+inline bool identityMeasurementFunction(
+  const V &variable,
+  ResultOut<FactorVariable<V>::Size> result,
+  JacobianOut<FactorVariable<V>::Size, FactorVariable<V>::Size> jacobian) {
+    result = variable;
+
+    if (jacobian) {
+        jacobian.setIdentity();
+    }
+
+    return true;
+}
+
+}  // namespace internal
+
 // Constructors
-FactorGraph::FactorGraph() {}
+inline FactorGraph::FactorGraph() {}
 
 // Capacity
 
-FactorGraph::size_type FactorGraph::countFactors() const noexcept {
+inline FactorGraph::size_type FactorGraph::countFactors() const noexcept {
     return this->factors.size();
 }
 
-bool FactorGraph::empty() const noexcept {
+inline bool FactorGraph::empty() const noexcept {
     return this->factors.empty();
 }
 
 // Modifiers
+
 template <typename FuncType, typename MeasType, typename... VarTypes>
-void FactorGraph::addFactor(FuncType f,
-                            const MeasType &meas,
-                            std::shared_ptr<VarTypes>... variables) {
+inline void FactorGraph::addFactor(FuncType f,
+                                   const MeasType &measurement,
+                                   std::shared_ptr<VarTypes>... variables) {
     using FactorType = Factor<MeasType, VarTypes...>;
 
     // Give a nice error message if the function type is wrong
@@ -26,28 +48,39 @@ void FactorGraph::addFactor(FuncType f,
       "The given measurement function is of incorrect type");
 
     this->factors.emplace_back(
-      std::make_shared<FactorType>(f, meas, std::move(variables)...));
+      std::make_shared<FactorType>(f, measurement, std::move(variables)...));
 };
+
+template <typename MeasType>
+inline void FactorGraph::addPrior(
+  const MeasType &measurement,
+  std::shared_ptr<typename MeasType::VarType> variable) {
+    return this->addFactor(
+      internal::identityMeasurementFunction<typename MeasType::ViewType>,
+      measurement,
+      std::move(variable));
+}
 
 // Iterators
 
-typename FactorGraph::iterator FactorGraph::begin() noexcept {
+inline typename FactorGraph::iterator FactorGraph::begin() noexcept {
     return this->factors.begin();
 }
 
-typename FactorGraph::iterator FactorGraph::end() noexcept {
+inline typename FactorGraph::iterator FactorGraph::end() noexcept {
     return this->factors.end();
 }
 
-typename FactorGraph::const_iterator FactorGraph::begin() const noexcept {
+inline typename FactorGraph::const_iterator FactorGraph::begin() const
+  noexcept {
     return this->factors.begin();
 }
 
-typename FactorGraph::const_iterator FactorGraph::end() const noexcept {
+inline typename FactorGraph::const_iterator FactorGraph::end() const noexcept {
     return this->factors.end();
 }
 
-std::ostream &operator<<(std::ostream &os, const FactorGraph &graph) {
+inline std::ostream &operator<<(std::ostream &os, const FactorGraph &graph) {
     os << "FactorGraph " << graph.countFactors() << " factors [";
     const auto N = graph.countFactors();
     for (auto i = 0 * N; i < N; ++i) {

--- a/wave_optimization/tests/factor_graph/example_instances.hpp
+++ b/wave_optimization/tests/factor_graph/example_instances.hpp
@@ -32,7 +32,10 @@ struct Pose2D : public ValueView<3> {
     // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67054)
     explicit Pose2D(double *d) : ValueView<3>{d} {}
     explicit Pose2D(MappedType &m) : ValueView<3>{m} {}
-
+    Pose2D &operator=(const Pose2D &other) {
+        this->ValueView<3>::operator=(other);
+        return *this;
+    }
     using Vec1 = Eigen::Matrix<double, 1, 1>;
 
     Eigen::Map<const Vec2> position{dataptr};
@@ -51,6 +54,10 @@ struct Landmark2D : public ValueView<2> {
     // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67054)
     explicit Landmark2D(double *d) : ValueView<2>{d} {}
     explicit Landmark2D(MappedType &m) : ValueView<2>{m} {}
+    Landmark2D &operator=(const Landmark2D &other) {
+        this->ValueView<2>::operator=(other);
+        return *this;
+    }
 
     Eigen::Map<const Vec2> position{dataptr};
 };

--- a/wave_optimization/tests/factor_graph/factor_test.cpp
+++ b/wave_optimization/tests/factor_graph/factor_test.cpp
@@ -91,31 +91,32 @@ TEST(FactorTest, evaluateCostFunction) {
       VectorsNear, expected_jac_landmark, Eigen::Map<Vec2>{out_jac_landmark});
 }
 
-TEST(FactorTest, idealMeasurement) {
-    using MeasType = FactorMeasurement<double, ZeroNoise>;
-    using VarType = FactorVariable<double>;
-    const auto &func = internal::identityMeasurementFunction<double>;
-    using FactorType = Factor<MeasType, VarType>;
-    auto v = std::make_shared<VarType>();
-
-    // Linking a variable to a factor with ZeroNoise measurement marks it fixed
-    FactorType{func, MeasType{1.2}, v};
-
-    EXPECT_TRUE(v->isFixed());
-}
-
-TEST(FactorTest, idealMeasurementConflict) {
-    using MeasType = FactorMeasurement<double, ZeroNoise>;
-    using VarType = FactorVariable<double>;
-    const auto &func = internal::identityMeasurementFunction<double>;
-    using FactorType = Factor<MeasType, VarType>;
-    auto v = std::make_shared<VarType>();
-
-    // The first factor marks the variable fixed
-    FactorType{func, MeasType{1.2}, v};
-
-    // The second one finds it is already fixed; there must be a conflict
-    EXPECT_THROW(FactorType(func, MeasType{1.2}, v), std::runtime_error);
-}
+// TEST(FactorTest, idealMeasurement) {
+//    using MeasType = FactorMeasurement<double, ZeroNoise>;
+//    using VarType = FactorVariable<double>;
+//    const auto &func = internal::identityMeasurementFunction<double>;
+//    using FactorType = Factor<MeasType, VarType>;
+//    auto v = std::make_shared<VarType>();
+//
+//    // Linking a variable to a factor with ZeroNoise measurement marks it
+//    fixed
+//    FactorType{func, MeasType{1.2}, v};
+//
+//    EXPECT_TRUE(v->isFixed());
+//}
+//
+// TEST(FactorTest, idealMeasurementConflict) {
+//    using MeasType = FactorMeasurement<double, ZeroNoise>;
+//    using VarType = FactorVariable<double>;
+//    const auto &func = internal::identityMeasurementFunction<double>;
+//    using FactorType = Factor<MeasType, VarType>;
+//    auto v = std::make_shared<VarType>();
+//
+//    // The first factor marks the variable fixed
+//    FactorType{func, MeasType{1.2}, v};
+//
+//    // The second one finds it is already fixed; there must be a conflict
+//    EXPECT_THROW(FactorType(func, MeasType{1.2}, v), std::runtime_error);
+//}
 
 }  // namespace wave

--- a/wave_optimization/tests/factor_graph/factor_test.cpp
+++ b/wave_optimization/tests/factor_graph/factor_test.cpp
@@ -59,38 +59,6 @@ TEST(FactorTest, print) {
     EXPECT_EQ(expected.str(), ss.str());
 }
 
-TEST(FactorTest, evaluateCostFunction) {
-    auto meas = DistanceMeasurement{1.23, 1.0};
-    DistanceToLandmarkFactor f{
-      meas, std::make_shared<Pose2DVar>(), std::make_shared<Landmark2DVar>()};
-
-    // Prepare sample C-style arrays as used by Ceres
-    const double param_pose[3] = {1.1, 2.2, 3.3};
-    const double param_landmark[2] = {4.4, 5.5};
-    const double *const parameters[2] = {param_pose, param_landmark};
-    double out_residuals[1];
-    double out_jac_pose[3];
-    double out_jac_landmark[2];
-    double *out_jacobians[2] = {out_jac_pose, out_jac_landmark};
-
-    // Calculate expected values (use analytic jacobians)
-    auto dist =
-      std::sqrt((1.1 - 4.4) * (1.1 - 4.4) + (2.2 - 5.5) * (2.2 - 5.5));
-    auto expected_residual = dist - 1.23;
-    Vec3 expected_jac_pose{(1.1 - 4.4) / dist, (2.2 - 5.5) / dist, 0};
-    Vec2 expected_jac_landmark{(1.1 - 4.4) / dist, (2.2 - 5.5) / dist};
-
-    // Call and compare
-    auto p_costfn = f.costFunction();
-    auto res = p_costfn->Evaluate(parameters, out_residuals, out_jacobians);
-    EXPECT_TRUE(res);
-    EXPECT_DOUBLE_EQ(expected_residual, out_residuals[0]);
-    EXPECT_PRED2(
-      VectorsNear, expected_jac_pose, Eigen::Map<Vec3>{out_jac_pose});
-    EXPECT_PRED2(
-      VectorsNear, expected_jac_landmark, Eigen::Map<Vec2>{out_jac_landmark});
-}
-
 // TEST(FactorTest, idealMeasurement) {
 //    using MeasType = FactorMeasurement<double, ZeroNoise>;
 //    using VarType = FactorVariable<double>;

--- a/wave_optimization/tests/factor_graph/factor_test.cpp
+++ b/wave_optimization/tests/factor_graph/factor_test.cpp
@@ -79,7 +79,8 @@ TEST(FactorTest, evaluateSize1) {
     // Compare the result. We expect the residual to be L(f(X) - Z)
     // In this case that is (2x - Z)/stddev
     EXPECT_DOUBLE_EQ((test_val * 2 - meas_val) / meas_stddev, test_residual);
-    EXPECT_DOUBLE_EQ(-1.1, test_jac);
+    // We expect the jacobian to be normalized as well
+    EXPECT_DOUBLE_EQ(-1.1 / meas_stddev, test_jac);
 }
 
 

--- a/wave_optimization/tests/factor_graph/factor_test.cpp
+++ b/wave_optimization/tests/factor_graph/factor_test.cpp
@@ -13,7 +13,7 @@ TEST(FactorTest, evaluate) {
     using Landmark2DVar = FactorVariable<Landmark2D>;
 
 
-    DistanceToLandmarkFactor f{DistanceMeasurement{meas, 0.0},
+    DistanceToLandmarkFactor f{DistanceMeasurement{meas, 1.0},
                                std::make_shared<Pose2DVar>(),
                                std::make_shared<Landmark2DVar>()};
 
@@ -46,7 +46,7 @@ TEST(FactorTest, evaluate) {
 TEST(FactorTest, print) {
     auto v1 = std::make_shared<Pose2DVar>();
     auto v2 = std::make_shared<Landmark2DVar>();
-    auto meas = DistanceMeasurement{0.0, 0.0};
+    auto meas = DistanceMeasurement{0.0, 1.0};
 
     auto factor = DistanceToLandmarkFactor{meas, v1, v2};
 
@@ -60,7 +60,7 @@ TEST(FactorTest, print) {
 }
 
 TEST(FactorTest, evaluateCostFunction) {
-    auto meas = DistanceMeasurement{1.23, 0.0};
+    auto meas = DistanceMeasurement{1.23, 1.0};
     DistanceToLandmarkFactor f{
       meas, std::make_shared<Pose2DVar>(), std::make_shared<Landmark2DVar>()};
 

--- a/wave_optimization/tests/factor_graph/factor_test.cpp
+++ b/wave_optimization/tests/factor_graph/factor_test.cpp
@@ -59,32 +59,19 @@ TEST(FactorTest, print) {
     EXPECT_EQ(expected.str(), ss.str());
 }
 
-// TEST(FactorTest, idealMeasurement) {
-//    using MeasType = FactorMeasurement<double, ZeroNoise>;
-//    using VarType = FactorVariable<double>;
-//    const auto &func = internal::identityMeasurementFunction<double>;
-//    using FactorType = Factor<MeasType, VarType>;
-//    auto v = std::make_shared<VarType>();
-//
-//    // Linking a variable to a factor with ZeroNoise measurement marks it
-//    fixed
-//    FactorType{func, MeasType{1.2}, v};
-//
-//    EXPECT_TRUE(v->isFixed());
-//}
-//
-// TEST(FactorTest, idealMeasurementConflict) {
-//    using MeasType = FactorMeasurement<double, ZeroNoise>;
-//    using VarType = FactorVariable<double>;
-//    const auto &func = internal::identityMeasurementFunction<double>;
-//    using FactorType = Factor<MeasType, VarType>;
-//    auto v = std::make_shared<VarType>();
-//
-//    // The first factor marks the variable fixed
-//    FactorType{func, MeasType{1.2}, v};
-//
-//    // The second one finds it is already fixed; there must be a conflict
-//    EXPECT_THROW(FactorType(func, MeasType{1.2}, v), std::runtime_error);
-//}
+TEST(FactorTest, perfectPrior) {
+    // Test that using a perfect prior immediately sets the variable's value
+    // Note explicitly constructing PerfectPrior is not intended for users -
+    // They should use FactorGraph::addPerfectPrior. That is why this test does
+    // some non-intuitive preparation (e.g. constructing a FactorMeasurement)
+    using MeasType = FactorMeasurement<double, void>;
+    using VarType = FactorVariable<double>;
+    const auto &func = internal::identityMeasurementFunction<double>;
+    using FactorType = PerfectPrior<VarType>;
+    auto v = std::make_shared<VarType>();
+
+    PerfectPrior<VarType>{MeasType{1.2}, v};
+    EXPECT_DOUBLE_EQ(1.2, v->value);
+}
 
 }  // namespace wave

--- a/wave_optimization/tests/factor_graph/graph_test.cpp
+++ b/wave_optimization/tests/factor_graph/graph_test.cpp
@@ -37,8 +37,9 @@ TEST(FactorGraph, addPrior) {
     const auto test_meas = Vec2{1.2, 3.4};
     const auto test_stddev = Vec2{0.01, 0.01};
     const auto test_val = Vec2{1.23, 3.38};
-    // The expected residuals are normalized
+    // The expected results are normalized
     const Vec2 expected_res = (test_val - test_meas).cwiseQuotient(test_stddev);
+    const Mat2 expected_jac = Mat2::Identity() / 0.01;
 
     // Prepare arguments to add unary factor
     FactorGraph graph;
@@ -60,14 +61,16 @@ TEST(FactorGraph, addPrior) {
 
     EXPECT_TRUE(factor->evaluateRaw(params, test_residual.data(), jacs));
     EXPECT_PRED2(VectorsNear, expected_res, test_residual);
-    EXPECT_PRED2(MatricesNear, Mat2::Identity(), test_jac);
+    EXPECT_PRED2(MatricesNear, expected_jac, test_jac);
 }
 
 TEST(FactorGraph, addPriorOfSize1) {
     const auto test_meas = 1.2;
     const auto test_stddev = 0.01;
     const auto test_val = 1.23;
+    // The expected results are normalized
     const auto expected_res = (test_val - test_meas) / test_stddev;
+    const auto expected_jac = 1.0 / test_stddev;
 
     // Prepare arguments to add unary factor
     FactorGraph graph;
@@ -89,7 +92,7 @@ TEST(FactorGraph, addPriorOfSize1) {
 
     EXPECT_TRUE(factor->evaluateRaw(params, &test_residual, jacs));
     EXPECT_DOUBLE_EQ(expected_res, test_residual);
-    EXPECT_DOUBLE_EQ(1.0, test_jac);
+    EXPECT_DOUBLE_EQ(expected_jac, test_jac);
 }
 
 TEST(FactorGraph, addPerfectPrior) {

--- a/wave_optimization/tests/factor_graph/graph_test.cpp
+++ b/wave_optimization/tests/factor_graph/graph_test.cpp
@@ -110,16 +110,49 @@ TEST(FactorGraph, addPerfectPrior) {
     graph.addPerfectPrior(test_meas, p);
     EXPECT_EQ(1u, graph.countFactors());
 
-    // The variable should now be marked constant
-    //    EXPECT_TRUE(p->isFixed());
+    // The variable should have the measured value immediately
+    // @todo this may change
+    EXPECT_PRED2(VectorsNear, test_meas, Eigen::Map<Vec2>(p->data()));
 
     // Retrieve a pointer to the factor we just (indirectly) added
     auto factor = *graph.begin();
     ASSERT_NE(nullptr, factor);
 
+    EXPECT_TRUE(factor->isPerfectPrior());
+
     // We cannot evaluate a factor that is a perfect prior
-    // Since evaluateRaw is nothrow, the program will die
     EXPECT_FALSE(factor->evaluateRaw(params, test_residual.data(), jacs));
+}
+
+TEST(FactorGraph, addPerfectPriorOfSize1) {
+    const auto test_meas = 1.2;
+    const auto test_val = 1.23;
+
+    // Prepare arguments to add unary factor
+    FactorGraph graph;
+    auto p = std::make_shared<FactorVariable<double>>();
+
+    // Prepare arguments in a form matching ceres calls
+    double test_residual;
+    double test_jac;
+    const double *const params[] = {&test_val};
+    double *jacs[] = {&test_jac};
+
+    // Add the factor
+    graph.addPerfectPrior(test_meas, p);
+    EXPECT_EQ(1u, graph.countFactors());
+
+    // The variable should have the measured value immediately
+    // @todo this may change
+    EXPECT_DOUBLE_EQ(test_meas, *p->data());
+
+    auto factor = *graph.begin();
+    ASSERT_NE(nullptr, factor);
+
+    EXPECT_TRUE(factor->isPerfectPrior());
+
+    // We cannot evaluate a factor that is a perfect prior
+    EXPECT_FALSE(factor->evaluateRaw(params, &test_residual, jacs));
 }
 
 TEST(FactorGraph, triangulationSim) {

--- a/wave_optimization/tests/factor_graph/noise_test.cpp
+++ b/wave_optimization/tests/factor_graph/noise_test.cpp
@@ -4,7 +4,7 @@
 namespace wave {
 
 TEST(NoiseTest, diagonalNoise) {
-    const auto stddev = Vec2{1.1, 2.2};
+    const DiagonalNoise<2>::InitType stddev = Vec2{1.1, 2.2};
     Eigen::Matrix2d expected_cov, expected_inv;
     expected_cov << 1.1 * 1.1, 0, 0, 2.2 * 2.2;
     expected_inv << 1 / 1.1, 0, 0, 1 / 2.2;
@@ -19,7 +19,7 @@ TEST(NoiseTest, diagonalNoise) {
 }
 
 TEST(NoiseTest, singleNoise) {
-    const auto stddev = 1.1;
+    const DiagonalNoise<1>::InitType stddev = 1.1;
 
     auto n = DiagonalNoise<1>{stddev};
     EXPECT_DOUBLE_EQ(stddev * stddev, n.covariance());
@@ -27,7 +27,7 @@ TEST(NoiseTest, singleNoise) {
 }
 
 TEST(NoiseTest, fullNoise) {
-    auto cov = Mat2{};
+    FullNoise<2>::InitType cov = Mat2{};
     cov << 3.3, 1.1, 1.1, 4.4;
 
     auto n = FullNoise<2>{cov};

--- a/wave_optimization/tests/factor_graph/noise_test.cpp
+++ b/wave_optimization/tests/factor_graph/noise_test.cpp
@@ -1,0 +1,51 @@
+#include "wave/wave_test.hpp"
+#include "wave/optimization/factor_graph/Noise.hpp"
+
+namespace wave {
+
+TEST(NoiseTest, diagonalNoise) {
+    const auto stddev = Vec2{1.1, 2.2};
+    Eigen::Matrix2d expected_cov, expected_inv;
+    expected_cov << 1.1 * 1.1, 0, 0, 2.2 * 2.2;
+    expected_inv << 1 / 1.1, 0, 0, 1 / 2.2;
+
+    auto n = DiagonalNoise<2>{stddev};
+
+    auto res = Eigen::MatrixXd{n.covariance()};
+    EXPECT_PRED2(MatricesNear, expected_cov, res);
+
+    res = Eigen::MatrixXd{n.inverseSqrtCov()};
+    EXPECT_PRED2(MatricesNear, expected_inv, res);
+}
+
+TEST(NoiseTest, singleNoise) {
+    const auto stddev = 1.1;
+
+    auto n = DiagonalNoise<1>{stddev};
+    EXPECT_DOUBLE_EQ(stddev * stddev, n.covariance());
+    EXPECT_DOUBLE_EQ(1. / stddev, n.inverseSqrtCov());
+}
+
+TEST(NoiseTest, fullNoise) {
+    auto cov = Mat2{};
+    cov << 3.3, 1.1, 1.1, 4.4;
+
+    auto n = FullNoise<2>{cov};
+
+    // inverse of cholesky of cov calculated separately
+    Mat2 expected_inv;
+    expected_inv << 0.550481882563180, 0, -0.165976532577323, 0.497929597731969;
+
+    auto res = Eigen::MatrixXd{n.covariance()};
+    EXPECT_PRED2(MatricesNear, cov, res);
+
+    res = Eigen::MatrixXd{n.inverseSqrtCov()};
+    EXPECT_PRED2(MatricesNear, expected_inv, res);
+}
+
+TEST(NoiseTest, zeroNoise) {
+    static_assert(std::is_empty<ZeroNoise>::value,
+                  "ZeroNoise expected to be have no data members.");
+}
+
+}  // namespace wave

--- a/wave_optimization/tests/factor_graph/noise_test.cpp
+++ b/wave_optimization/tests/factor_graph/noise_test.cpp
@@ -43,14 +43,4 @@ TEST(NoiseTest, fullNoise) {
     EXPECT_PRED2(MatricesNear, expected_inv, res);
 }
 
-TEST(NoiseTest, zeroNoise) {
-    static_assert(std::is_empty<ZeroNoise>::value,
-                  "ZeroNoise expected to be have no data members.");
-
-    auto n = ZeroNoise{};
-
-    EXPECT_THROW(n.covariance(), std::logic_error);
-    EXPECT_THROW(n.inverseSqrtCov(), std::logic_error);
-}
-
 }  // namespace wave

--- a/wave_optimization/tests/factor_graph/noise_test.cpp
+++ b/wave_optimization/tests/factor_graph/noise_test.cpp
@@ -46,6 +46,11 @@ TEST(NoiseTest, fullNoise) {
 TEST(NoiseTest, zeroNoise) {
     static_assert(std::is_empty<ZeroNoise>::value,
                   "ZeroNoise expected to be have no data members.");
+
+    auto n = ZeroNoise{};
+
+    EXPECT_THROW(n.covariance(), std::logic_error);
+    EXPECT_THROW(n.inverseSqrtCov(), std::logic_error);
 }
 
 }  // namespace wave

--- a/wave_optimization/tests/factor_graph/variable_test.cpp
+++ b/wave_optimization/tests/factor_graph/variable_test.cpp
@@ -87,19 +87,6 @@ TEST(VariableTest, moveAssign) {
     EXPECT_NE(a.data(), b.data());
 }
 
-TEST(VariableTest, setFixed) {
-    // Construct and initialize a variable
-    auto var = FactorVariable<ValueView<2>>{Vec2{1.1, 2.2}};
-
-    EXPECT_FALSE(var.isFixed());
-
-    var.setFixed(true);
-    EXPECT_TRUE(var.isFixed());
-
-    var.setFixed(false);
-    EXPECT_FALSE(var.isFixed());
-}
-
 TEST(MeasurementTest, constructFromRvalue) {
     auto meas = FactorMeasurement<ValueView<2>>{Vec2{1.1, 2.2}, Vec2{0.1, 0.2}};
     const auto expected_val = Vec2{1.1, 2.2};

--- a/wave_optimization/tests/factor_graph/variable_test.cpp
+++ b/wave_optimization/tests/factor_graph/variable_test.cpp
@@ -1,6 +1,6 @@
 #include "wave/wave_test.hpp"
 #include "wave/optimization/factor_graph/FactorVariable.hpp"
-
+#include "wave/optimization/factor_graph/FactorMeasurement.hpp"
 
 namespace wave {
 
@@ -85,6 +85,27 @@ TEST(VariableTest, moveAssign) {
 
     ASSERT_NE(&a, &b);
     EXPECT_NE(a.data(), b.data());
+}
+
+TEST(VariableTest, setFixed) {
+    // Construct and initialize a variable
+    auto var = FactorVariable<ValueView<2>>{Vec2{1.1, 2.2}};
+
+    EXPECT_FALSE(var.isFixed());
+
+    var.setFixed(true);
+    EXPECT_TRUE(var.isFixed());
+
+    var.setFixed(false);
+    EXPECT_FALSE(var.isFixed());
+}
+
+TEST(MeasurementTest, constructFromRvalue) {
+    auto meas = FactorMeasurement<ValueView<2>>{Vec2{1.1, 2.2}, Vec2{0.1, 0.2}};
+    const auto expected_val = Vec2{1.1, 2.2};
+    EXPECT_EQ(2, meas.size());
+    EXPECT_PRED2(
+      VectorsNear, expected_val, Eigen::Map<Vec2>{meas.value.data()});
 }
 
 }  // namespace wave

--- a/wave_optimization/tests/factor_graph/variable_test.cpp
+++ b/wave_optimization/tests/factor_graph/variable_test.cpp
@@ -49,4 +49,42 @@ TEST(VariableTest, constructInitialRvalue) {
     EXPECT_PRED2(VectorsNear, expected, Eigen::Map<Vec2>{var.value.data()});
 }
 
+TEST(VariableTest, copyConstruct) {
+    // Because FactorVariable works with pointers to its storage, it must have
+    // a custom copy constructor
+    FactorVariable<ValueView<2>> a{Vec2{1.1, 2.2}};
+    FactorVariable<ValueView<2>> b{a};
+
+    ASSERT_NE(&a, &b);
+    EXPECT_NE(a.data(), b.data());
+    EXPECT_DOUBLE_EQ(1.1, *a.data());
+    EXPECT_DOUBLE_EQ(1.1, *b.data());
+}
+
+TEST(VariableTest, moveConstruct) {
+    FactorVariable<ValueView<2>> a;
+    auto a_ptr = a.data();
+    FactorVariable<ValueView<2>> b{std::move(a)};
+
+    ASSERT_NE(&a, &b);
+    EXPECT_NE(a_ptr, b.data());
+}
+
+TEST(VariableTest, copyAssign) {
+    FactorVariable<ValueView<2>> a, b;
+    b = a;
+
+    ASSERT_NE(&a, &b);
+    EXPECT_NE(a.data(), b.data());
+}
+
+
+TEST(VariableTest, moveAssign) {
+    FactorVariable<ValueView<2>> a, b;
+    b = std::move(a);
+
+    ASSERT_NE(&a, &b);
+    EXPECT_NE(a.data(), b.data());
+}
+
 }  // namespace wave


### PR DESCRIPTION
Resolves #149
Depends on #137 (_do not merge; the base of this PR is not master_)

- Add Gaussian noise models (diagonal and full covariance)
- Normalize residuals when evaluating factors
- New methods: `addPrior` and `addPerfectPrior` (see their use in `graph_test.cpp`)
- Add PerfectPrior, the special case factor with zero noise (zero noise has to be a special case - see documentation)
- Move generation of Ceres cost function outside of the Factor class.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
