### PR TITLE
Fix 162 - Move ParamsStruct from .hpp to .cpp

### DIFF
--- a/wave_vision/include/wave/vision/descriptor/brisk_descriptor.hpp
+++ b/wave_vision/include/wave/vision/descriptor/brisk_descriptor.hpp
@@ -36,32 +36,7 @@ struct BRISKDescriptorParams {
      *
      *  @param config_path the path to the location of the configuration file
      */
-    BRISKDescriptorParams(const std::string &config_path) {
-        // Extract parameters from .yaml file.
-        ConfigParser parser;
-
-        std::vector<float> radius_list;
-        std::vector<int> number_list;
-        float d_max;
-        float d_min;
-
-        // Add parameters to parser, to be loaded. If path cannot be found,
-        // throw an exception
-        parser.addParam("radius_list", &radius_list);
-        parser.addParam("number_list", &number_list);
-        parser.addParam("d_max", &d_max);
-        parser.addParam("d_min", &d_min);
-
-        if (parser.load(config_path) != 0) {
-            throw std::invalid_argument(
-              "Failed to Load BRISKDescriptor Configuration");
-        }
-
-        this->radius_list = radius_list;
-        this->number_list = number_list;
-        this->d_max = d_max;
-        this->d_min = d_min;
-    }
+    BRISKDescriptorParams(const std::string &config_path);
 
     /** radius_list defines the radius of each subsequent circle (in pixels).
      *  All numbers must be positive. Cannot be empty.

--- a/wave_vision/include/wave/vision/detector/fast_detector.hpp
+++ b/wave_vision/include/wave/vision/detector/fast_detector.hpp
@@ -30,29 +30,7 @@ struct FASTParams {
      *
      *  @param config_path the path to the location of the configuration file
      */
-    FASTParams(const std::string &config_path) {
-        // Extract parameters from .yaml file.
-        ConfigParser parser;
-
-        int threshold;
-        bool nonmax_suppression;
-        int type;
-
-        // Add parameters to parser, to be loaded. If path cannot be found,
-        // throw an exception.
-        parser.addParam("threshold", &threshold);
-        parser.addParam("nonmax_suppression", &nonmax_suppression);
-        parser.addParam("type", &type);
-
-        if (parser.load(config_path) != 0) {
-            throw std::invalid_argument(
-              "Failed to Load FASTParams Configuration");
-        }
-
-        this->threshold = threshold;
-        this->nonmax_suppression = nonmax_suppression;
-        this->type = type;
-    }
+    FASTParams(const std::string &config_path);
 
     /** Threshold on difference between intensity of the central pixel, and
      *  pixels in a circle (Bresenham radius 3) around this pixel. Must be

--- a/wave_vision/include/wave/vision/matcher/brute_force_matcher.hpp
+++ b/wave_vision/include/wave/vision/matcher/brute_force_matcher.hpp
@@ -37,36 +37,7 @@ struct BFMatcherParams {
      *
      *  @param config_path the path to the location of the configuration file
      */
-    BFMatcherParams(const std::string &config_path) {
-        // Extract parameters from .yaml file.
-        ConfigParser parser;
-
-        int norm_type;
-        bool use_knn;
-        double ratio_threshold;
-        int distance_threshold;
-        int fm_method;
-
-        // Add parameters to parser, to be loaded. If path cannot be found,
-        // throw an
-        // exception.
-        parser.addParam("norm_type", &norm_type);
-        parser.addParam("use_knn", &use_knn);
-        parser.addParam("ratio_threshold", &ratio_threshold);
-        parser.addParam("distance_threshold", &distance_threshold);
-        parser.addParam("fm_method", &fm_method);
-
-        if (parser.load(config_path) != 0) {
-            throw std::invalid_argument(
-              "Failed to Load BRISKDescriptor Configuration");
-        }
-
-        this->norm_type = norm_type;
-        this->use_knn = use_knn;
-        this->ratio_threshold = ratio_threshold;
-        this->distance_threshold = distance_threshold;
-        this->fm_method = fm_method;
-    }
+    BFMatcherParams(const std::string &config_path);
 
     /** Norm type to use for distance calculation between feature descriptors.
      *

--- a/wave_vision/src/descriptor/brisk_descriptor.cpp
+++ b/wave_vision/src/descriptor/brisk_descriptor.cpp
@@ -22,7 +22,7 @@ BRISKDescriptorParams::BRISKDescriptorParams(const std::string &config_path) {
 
     if (parser.load(config_path) != 0) {
         throw std::invalid_argument(
-                "Failed to Load BRISKDescriptor Configuration");
+          "Failed to Load BRISKDescriptorParams Configuration");
     }
 
     this->radius_list = radius_list;

--- a/wave_vision/src/descriptor/brisk_descriptor.cpp
+++ b/wave_vision/src/descriptor/brisk_descriptor.cpp
@@ -3,6 +3,34 @@
 
 namespace wave {
 
+// Filesystem based constructor for BRISKDescriptorParams
+BRISKDescriptorParams::BRISKDescriptorParams(const std::string &config_path) {
+    // Extract parameters from .yaml file.
+    ConfigParser parser;
+
+    std::vector<float> radius_list;
+    std::vector<int> number_list;
+    float d_max;
+    float d_min;
+
+    // Add parameters to parser, to be loaded. If path cannot be found,
+    // throw an exception
+    parser.addParam("radius_list", &radius_list);
+    parser.addParam("number_list", &number_list);
+    parser.addParam("d_max", &d_max);
+    parser.addParam("d_min", &d_min);
+
+    if (parser.load(config_path) != 0) {
+        throw std::invalid_argument(
+                "Failed to Load BRISKDescriptor Configuration");
+    }
+
+    this->radius_list = radius_list;
+    this->number_list = number_list;
+    this->d_max = d_max;
+    this->d_min = d_min;
+}
+
 // Default constructor. Struct may be default or user defined.
 BRISKDescriptor::BRISKDescriptor(const BRISKDescriptorParams &config) {
     // Ensure parameters are valid

--- a/wave_vision/src/detector/fast_detector.cpp
+++ b/wave_vision/src/detector/fast_detector.cpp
@@ -3,6 +3,31 @@
 
 namespace wave {
 
+// Filesystem constructor for FASTParams struct
+FASTParams::FASTParams(const std::string &config_path) {
+    // Extract parameters from .yaml file.
+    ConfigParser parser;
+
+    int threshold;
+    bool nonmax_suppression;
+    int type;
+
+    // Add parameters to parser, to be loaded. If path cannot be found,
+    // throw an exception.
+    parser.addParam("threshold", &threshold);
+    parser.addParam("nonmax_suppression", &nonmax_suppression);
+    parser.addParam("type", &type);
+
+    if (parser.load(config_path) != 0) {
+        throw std::invalid_argument(
+                "Failed to Load FASTParams Configuration");
+    }
+
+    this->threshold = threshold;
+    this->nonmax_suppression = nonmax_suppression;
+    this->type = type;
+}
+
 // Default Constructor
 FASTDetector::FASTDetector(const FASTParams &config) {
     // Ensure parameters are valid

--- a/wave_vision/src/detector/fast_detector.cpp
+++ b/wave_vision/src/detector/fast_detector.cpp
@@ -19,8 +19,7 @@ FASTParams::FASTParams(const std::string &config_path) {
     parser.addParam("type", &type);
 
     if (parser.load(config_path) != 0) {
-        throw std::invalid_argument(
-                "Failed to Load FASTParams Configuration");
+        throw std::invalid_argument("Failed to Load FASTParams Configuration");
     }
 
     this->threshold = threshold;

--- a/wave_vision/src/matcher/brute_force_matcher.cpp
+++ b/wave_vision/src/matcher/brute_force_matcher.cpp
@@ -3,6 +3,38 @@
 
 namespace wave {
 
+// Filesystem based constructor for BFMatcherParams
+BFMatcherParams::BFMatcherParams(const std::string &config_path) {
+    // Extract parameters from .yaml file.
+    ConfigParser parser;
+
+    int norm_type;
+    bool use_knn;
+    double ratio_threshold;
+    int distance_threshold;
+    int fm_method;
+
+    // Add parameters to parser, to be loaded. If path cannot be found,
+    // throw an
+    // exception.
+    parser.addParam("norm_type", &norm_type);
+    parser.addParam("use_knn", &use_knn);
+    parser.addParam("ratio_threshold", &ratio_threshold);
+    parser.addParam("distance_threshold", &distance_threshold);
+    parser.addParam("fm_method", &fm_method);
+
+    if (parser.load(config_path) != 0) {
+        throw std::invalid_argument(
+                "Failed to Load BRISKDescriptor Configuration");
+    }
+
+    this->norm_type = norm_type;
+    this->use_knn = use_knn;
+    this->ratio_threshold = ratio_threshold;
+    this->distance_threshold = distance_threshold;
+    this->fm_method = fm_method;
+}
+
 // Default constructor. Struct may be default or user defined.
 BruteForceMatcher::BruteForceMatcher(const BFMatcherParams &config) {
     bool cross_check;

--- a/wave_vision/src/matcher/brute_force_matcher.cpp
+++ b/wave_vision/src/matcher/brute_force_matcher.cpp
@@ -25,7 +25,7 @@ BFMatcherParams::BFMatcherParams(const std::string &config_path) {
 
     if (parser.load(config_path) != 0) {
         throw std::invalid_argument(
-                "Failed to Load BRISKDescriptor Configuration");
+          "Failed to Load BFMatcherParams Configuration");
     }
 
     this->norm_type = norm_type;


### PR DESCRIPTION
Resolves #162. Moves filesystem based constructor into .cpp file from .hpp.