### PR TITLE
Add conversion from cv::KeyPoint to Vec2

### DIFF
--- a/wave_vision/include/wave/vision/utils.hpp
+++ b/wave_vision/include/wave/vision/utils.hpp
@@ -43,6 +43,13 @@ Vec2 focal_length(double hfov,
  */
 void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P);
 
+/** Convert a single cv::KeyPoint to a Vec2 object
+ *
+ * @param keypoint input keypoint
+ * @param vec_keypoints converted keypoint
+ */
+void convertKeypoints(const cv::KeyPoint &keypoint, Vec2 &vec_keypoints);
+
 /** Convert a vector of keypoints to a vector of Vec2
  *
  * @param keypoints input keypoints

--- a/wave_vision/include/wave/vision/utils.hpp
+++ b/wave_vision/include/wave/vision/utils.hpp
@@ -43,7 +43,7 @@ Vec2 focal_length(double hfov,
  */
 void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P);
 
-/** Convert a single cv::KeyPoint to a Vec2 object
+/** Convert a single cv::KeyPoint to a Vec2
  *
  * @param keypoint input keypoint
  * @param vec_keypoints converted keypoint

--- a/wave_vision/include/wave/vision/utils.hpp
+++ b/wave_vision/include/wave/vision/utils.hpp
@@ -48,7 +48,7 @@ void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P);
  * @param keypoint input keypoint
  * @param vec_keypoints converted keypoint
  */
-void convertKeypoints(const cv::KeyPoint &keypoint, Vec2 &vec_keypoints);
+void convertKeypoint(const cv::KeyPoint &keypoint, Vec2 &vec_keypoint);
 
 /** Convert a vector of keypoints to a vector of Vec2
  *

--- a/wave_vision/include/wave/vision/utils.hpp
+++ b/wave_vision/include/wave/vision/utils.hpp
@@ -43,6 +43,14 @@ Vec2 focal_length(double hfov,
  */
 void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P);
 
+/** Convert a vector of keypoints to a vector of Vec2
+ *
+ * @param keypoints input keypoints
+ * @param vec_keypoints converted keypoints
+ */
+void convertKeypoints(const std::vector<cv::KeyPoint> &keypoints,
+                      std::vector<Vec2> &vec_keypoints);
+
 /** @} group vision */
 }  // namespace wave
 

--- a/wave_vision/src/utils.cpp
+++ b/wave_vision/src/utils.cpp
@@ -27,4 +27,13 @@ void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P) {
     P = K * extrinsics;
 }
 
+void convertKeypoints(const std::vector<cv::KeyPoint> &keypoints,
+                      std::vector<Vec2> &vec_keypoints) {
+    for (const auto &k : keypoints) {
+        Vec2 v(k.pt.x, k.pt.y);
+
+        vec_keypoints.emplace_back(v);
+    }
+}
+
 }  // namespace wave

--- a/wave_vision/src/utils.cpp
+++ b/wave_vision/src/utils.cpp
@@ -27,10 +27,19 @@ void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P) {
     P = K * extrinsics;
 }
 
+void convertKeypoints(const cv::KeyPoint &keypoint, Vec2 &vec_keypoints) {
+    Vec2 v(keypoint.pt.x, keypoint.pt.y);
+
+    vec_keypoints = v;
+}
+
 void convertKeypoints(const std::vector<cv::KeyPoint> &keypoints,
                       std::vector<Vec2> &vec_keypoints) {
+    Vec2 v;
+
     for (const auto &k : keypoints) {
-        Vec2 v(k.pt.x, k.pt.y);
+        v(0) = k.pt.x;
+        v(1) = k.pt.y;
 
         vec_keypoints.emplace_back(v);
     }

--- a/wave_vision/src/utils.cpp
+++ b/wave_vision/src/utils.cpp
@@ -27,22 +27,15 @@ void projection_matrix(const Mat3 &K, const Mat3 &R, const Vec3 &t, MatX &P) {
     P = K * extrinsics;
 }
 
-void convertKeypoints(const cv::KeyPoint &keypoint, Vec2 &vec_keypoints) {
-    Vec2 v(keypoint.pt.x, keypoint.pt.y);
-
-    vec_keypoints = v;
+void convertKeypoint(const cv::KeyPoint &keypoint, Vec2 &vec_keypoint) {
+    vec_keypoint(0) = keypoint.pt.x;
+    vec_keypoint(1) = keypoint.pt.y;
 }
 
 void convertKeypoints(const std::vector<cv::KeyPoint> &keypoints,
                       std::vector<Vec2> &vec_keypoints) {
-    Vec2 v;
-
     for (const auto &k : keypoints) {
-        v(0) = k.pt.x;
-        v(1) = k.pt.y;
-
-        vec_keypoints.emplace_back(v);
+        vec_keypoints.emplace_back(k.pt.x, k.pt.y);
     }
 }
-
 }  // namespace wave

--- a/wave_vision/tests/utils_tests.cpp
+++ b/wave_vision/tests/utils_tests.cpp
@@ -48,4 +48,27 @@ TEST(VisionCommon, projection_matrix) {
     EXPECT_PRED2(MatricesNear, expected, P);
 }
 
+TEST(VisionCommon, convert_keypoints) {
+    cv::KeyPoint keypoint1(5.f, 5.f, 1.f);
+    cv::KeyPoint keypoint2(7.f, 2.f, 1.f);
+    cv::KeyPoint keypoint3(1.f, 8.f, 1.f);
+
+    std::vector<cv::KeyPoint> keypoints;
+
+    keypoints.emplace_back(keypoint1);
+    keypoints.emplace_back(keypoint2);
+    keypoints.emplace_back(keypoint3);
+
+    std::vector<Vec2> converted;
+
+    convertKeypoints(keypoints, converted);
+
+    ASSERT_EQ(converted.at(0)(0), keypoint1.pt.x);
+    ASSERT_EQ(converted.at(0)(1), keypoint1.pt.y);
+    ASSERT_EQ(converted.at(1)(0), keypoint2.pt.x);
+    ASSERT_EQ(converted.at(1)(1), keypoint2.pt.y);
+    ASSERT_EQ(converted.at(2)(0), keypoint3.pt.x);
+    ASSERT_EQ(converted.at(2)(1), keypoint3.pt.y);
+}
+
 }  // namespace wave

--- a/wave_vision/tests/utils_tests.cpp
+++ b/wave_vision/tests/utils_tests.cpp
@@ -55,8 +55,8 @@ TEST(VisionCommon, convert_single_keypoint) {
     Vec2 conv1;
     Vec2 conv2;
 
-    convertKeypoints(keypoint1, conv1);
-    convertKeypoints(keypoint2, conv2);
+    convertKeypoint(keypoint1, conv1);
+    convertKeypoint(keypoint2, conv2);
 
     ASSERT_EQ(keypoint1.pt.x, conv1(0));
     ASSERT_EQ(keypoint1.pt.y, conv1(1));

--- a/wave_vision/tests/utils_tests.cpp
+++ b/wave_vision/tests/utils_tests.cpp
@@ -71,9 +71,9 @@ TEST(VisionCommon, convert_keypoints) {
 
     std::vector<cv::KeyPoint> keypoints;
 
-    keypoints.emplace_back(keypoint1);
-    keypoints.emplace_back(keypoint2);
-    keypoints.emplace_back(keypoint3);
+    keypoints.push_back(keypoint1);
+    keypoints.push_back(keypoint2);
+    keypoints.push_back(keypoint3);
 
     std::vector<Vec2> converted;
 

--- a/wave_vision/tests/utils_tests.cpp
+++ b/wave_vision/tests/utils_tests.cpp
@@ -48,6 +48,22 @@ TEST(VisionCommon, projection_matrix) {
     EXPECT_PRED2(MatricesNear, expected, P);
 }
 
+TEST(VisionCommon, convert_single_keypoint) {
+    cv::KeyPoint keypoint1(5.f, 5.f, 1.f);
+    cv::KeyPoint keypoint2(-1.f, 2.f, 1.f);
+
+    Vec2 conv1;
+    Vec2 conv2;
+
+    convertKeypoints(keypoint1, conv1);
+    convertKeypoints(keypoint2, conv2);
+
+    ASSERT_EQ(keypoint1.pt.x, conv1(0));
+    ASSERT_EQ(keypoint1.pt.y, conv1(1));
+    ASSERT_EQ(keypoint2.pt.x, conv2(0));
+    ASSERT_EQ(keypoint2.pt.y, conv2(1));
+}
+
 TEST(VisionCommon, convert_keypoints) {
     cv::KeyPoint keypoint1(5.f, 5.f, 1.f);
     cv::KeyPoint keypoint2(7.f, 2.f, 1.f);


### PR DESCRIPTION
Resolves #164. Adds in a vision utility to convert between cv::KeyPoints and Vec2. Utilities in place for both a vector of cv::KeyPoint, or a single keypoint as well.
