### PR TITLE
VOTestDataset: separate generation and file output

### DIFF
--- a/wave_vision/include/wave/vision/dataset.hpp
+++ b/wave_vision/include/wave/vision/dataset.hpp
@@ -63,19 +63,47 @@ class VOTestCamera {
                       std::vector<std::pair<Vec2, Vec3>> &observed);
 };
 
+/** A set of feature observations at one timestep */
+struct VOTestInstant {
+    /** A time in nominal seconds */
+    double time;
+
+    /** The corresponding camera frame, or -1 if no camera observations */
+    int camera_frame = -1;
+
+    /** Robot pose in x, y, z (NWU) */
+    Vec3 robot_pose;
+
+    /** Feature observations where the first of each pair is the measurement in
+     * the image frame, and the second is the world feature coordinates.
+     */
+    std::vector<std::pair<Vec2, Vec3>> observed;
+};
+
+/**
+ * A set of generated dataset data.
+ *
+ * This includes:
+ * - Robot pose (robot ground truth)
+ * - 3D Features in the world (landmark ground truth)
+ * - 3D Features observed in image frame on the two wheel robot
+ */
+struct VOTestDataset {
+    /** Ground truth 3D world features, where each column represents a feature
+     * and each row represents the feature position in x, y, z (NWU)  */
+    MatX features;
+
+    /** For each time step, a set of measurements */
+    std::vector<VOTestInstant> measurements;
+};
+
 /**
  * Synthetic VO dataset generator.
  *
  * This class simulates a two wheel robot traversing in circle where the world
- * has 3D random feature points, and records:
- *
- * - Robot pose (robot ground truth)
- * - 3D Features in the world (landmark ground truth)
- * - 3D Features observed in image frame on the two wheel robot
- *
- * in separate files and in a dedicated folder.
+ * has 3D random feature points, and stores the data in a VOTestDataset object.
  */
-class VOTestDataset {
+class VOTestDatasetGenerator {
  public:
     VOTestCamera camera;
     int nb_features;
@@ -83,13 +111,13 @@ class VOTestDataset {
     Vec2 feature_y_bounds;
     Vec2 feature_z_bounds;
 
-    VOTestDataset()
+    VOTestDatasetGenerator()
         : camera{},
           nb_features{-1},
           feature_x_bounds{},
           feature_y_bounds{},
           feature_z_bounds{} {}
-    explicit VOTestDataset(const std::string &config_file);
+    explicit VOTestDatasetGenerator(const std::string &config_file);
 
     /** Generate random 3D features in the world frame
      *
@@ -99,50 +127,67 @@ class VOTestDataset {
      */
     void generateRandom3DFeatures(MatX &features);
 
-    /** Record 3D features to file in csv format
-     *
-     * The csv format has each row representing a feature and each column
-     * representing the feature position in x, y, z (NWU)
-     *
-     * @param output_path Output path to save 3D features, the resulting file
-     * will be in `<output_path>/features.dat`
-     * @param features 3D features to save
-     */
-    void record3DFeatures(const std::string &output_path, const MatX &features);
-
-    /** Record observed features in camera frame to file in csv format
-     *
-     * The csv format is as follows:
-     *
-     * - Time_step
-     * - Number of features observed
-     * - Features x, y, z (NWU) where has each row representing a feature and
-     *   each column representing the feature position in x, y, z (NWU)
-     *
-     * @param time Time stamp
-     * @param x Robot pose in x, y, z (NWU)
-     * @param output_path Output destination for observed features
-     * @param observed Observed features in both image and world frame
-     */
-    void recordObservedFeatures(double time,
-                                const Vec3 &x,
-                                const std::string &output_path,
-                                std::vector<std::pair<Vec2, Vec3>> &observed);
-
-
-    /** This class simulates a two wheel robot traversing in circle where the
-     * world has 3D random feature points, and records:
+    /** Simulates a two wheel robot traversing in a world with random 3D feature
+     * points, and records:
      *
      * - Robot pose (robot ground truth)
      * - 3D Features in the world (landmark ground truth)
      * - 3D Features observed in image frame on the two wheel robot
      *
-     * in separate files and in a dedicated folder.
+     * in a VOTestDataset object.
      *
-     * @param output_path Dataset destination
+     * A measurement including robot pose is stored at every timestep (with an
+     * arbitrary dt), but feature observations are only made at some timesteps.
      */
-    void generateTestData(const std::string &output_path);
+    VOTestDataset generate();
 };
+
+
+/** Record observed features in camera frame to file in csv format
+ *
+ * The csv format is as follows:
+ *
+ * - Time_step
+ * - Number of features observed
+ * - Features x, y, z (NWU) where has each row representing a feature and
+ *   each column representing the feature position in x, y, z (NWU)
+ *
+ * @param measurements object containing the time, pose, and observations
+ * @param output_path output file which will be created
+ */
+void recordMeasurements(const VOTestInstant &measurements,
+                        const std::string &output_path);
+
+/** Record 3D features to file in csv format
+ *
+ * The csv format has each row representing a feature and each column
+ * representing the feature position in x, y, z (NWU)
+ *
+ * @param features 3D features to save
+ * @param output_path output file which will be created
+ */
+void record3DFeatures(const MatX &features, const std::string &output_path);
+
+/**
+ * Records a generated dataset to separate files.
+ *
+ * @param dataset the dataset object
+ * @param output_path destination directory
+ *
+ * The following files are stored in csv format:
+ *
+ * - features.dat (see `record3DFeatures`)
+ * - state.dat robot position (x, y, angle) at each timestep with a header
+ * - observed_*.dat, N files with feature observations (see
+ *   `recordMeasurements`)
+ * - index.dat, listing the N files above
+ *
+ * @todo fix the documentation of csv format. For some files the header does not
+ * seem to refer the actual contents, etc.
+ */
+void recordTestData(const VOTestDataset &dataset,
+                    const std::string &output_path);
+
 
 /** @} end of group */
 }  // namespace wave

--- a/wave_vision/tests/dataset_tests.cpp
+++ b/wave_vision/tests/dataset_tests.cpp
@@ -61,13 +61,13 @@ TEST(VOTestCamera, checkFeatures) {
 
 TEST(VOTestDataset, constructor) {
     // test default constructor
-    VOTestDataset dataset;
+    VOTestDatasetGenerator dataset;
 
     EXPECT_EQ(-1, dataset.camera.image_width);
     EXPECT_EQ(-1, dataset.camera.image_height);
 
     // test constructor with config file path as argument
-    VOTestDataset dataset2(TEST_CONFIG);
+    VOTestDatasetGenerator dataset2(TEST_CONFIG);
 
     EXPECT_EQ(640, dataset2.camera.image_width);
     EXPECT_EQ(640, dataset2.camera.image_height);
@@ -79,10 +79,18 @@ TEST(VOTestDataset, constructor) {
 }
 
 TEST(VOTestDataset, generateTestData) {
-    VOTestDataset dataset(TEST_CONFIG);
+    VOTestDatasetGenerator generator(TEST_CONFIG);
+    auto dataset = generator.generate();
+
+    EXPECT_EQ(100u, dataset.features.cols());
+}
+
+TEST(VOTestDataset, writeTestDataToFile) {
+    VOTestDatasetGenerator generator(TEST_CONFIG);
+    auto dataset = generator.generate();
 
     boost::filesystem::remove_all(TEST_OUTPUT);
-    dataset.generateTestData(TEST_OUTPUT);
+    recordTestData(dataset, TEST_OUTPUT);
     EXPECT_NO_THROW();
 }
 


### PR DESCRIPTION
Resolves #169 

- Rename VOTestDataset to VOTestDatasetGenerator: a class which generates a dataset
- Add VOTestDataset struct which contains the simulated ground truth and measurements
- Split VOTestDataset::generateTestData() into two functions:
   - VOTestDatasetGenerator::generate() creates the dataset
   - writeTestDataToFile() takes the dataset and writes it to files


#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests (only slightly more than before..)
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
