### PR TITLE
LandmarkMeasurementContainer: Specify behaviour with instantaneous time window 

### DIFF
--- a/wave_containers/include/wave/containers/impl/landmark_measurement_container.hpp
+++ b/wave_containers/include/wave/containers/impl/landmark_measurement_container.hpp
@@ -228,7 +228,7 @@ LandmarkMeasurementContainer<T>::getTrackInWindow(const SensorIdType &s,
                                                   const TimeType &end) const
   noexcept {
     // Consider a "backwards" window empty
-    if (start >= end) {
+    if (start > end) {
         return Track{};
     }
 

--- a/wave_containers/include/wave/containers/impl/landmark_measurement_container.hpp
+++ b/wave_containers/include/wave/containers/impl/landmark_measurement_container.hpp
@@ -194,7 +194,7 @@ LandmarkMeasurementContainer<T>::getLandmarkIDsInWindow(
       typename internal::landmark_container<T>::landmark_index>();
     auto unique_ids = std::vector<LandmarkIdType>{};
 
-    // Iterate over all measurements sorted by time, first then landmark_id.
+    // Iterate over all measurements sorted by time first, then landmark_id.
     // Copy landmark ids into a vector, skipping consecutive equal elements and
     // elements outside the desired time window.
     for (auto &meas : landmark_index) {

--- a/wave_containers/include/wave/containers/landmark_measurement_container.hpp
+++ b/wave_containers/include/wave/containers/landmark_measurement_container.hpp
@@ -167,7 +167,12 @@ class LandmarkMeasurementContainer {
     /** Get a list of all unique landmark IDs in the container */
     std::vector<LandmarkIdType> getLandmarkIDs() const;
 
-    /** Get unique landmark IDs with measurements in the time window */
+    /** Get unique landmark IDs with measurements in the time window
+     *
+     * @return a vector of landmark IDs, in increasing order
+     *
+     * If `start > end`, the result will be empty.
+     */
     std::vector<LandmarkIdType> getLandmarkIDsInWindow(
       const TimeType &start, const TimeType &end) const;
 
@@ -178,12 +183,13 @@ class LandmarkMeasurementContainer {
     Track getTrack(const SensorIdType &s, const LandmarkIdType &id) const
       noexcept;
 
-    /** Get a sequnce of measurements of a landmark from one sensor, in the
-     * given
-     * time window.
+    /** Get a sequence of measurements of a landmark from one sensor, in the
+     * given time window.
      *
      * @return a vector of landmark measurements sorted by time
-      */
+     *
+     * If `start >= end`, the result will be empty.
+     */
     Track getTrackInWindow(const SensorIdType &s,
                            const LandmarkIdType &id,
                            const TimeType &start,

--- a/wave_containers/include/wave/containers/landmark_measurement_container.hpp
+++ b/wave_containers/include/wave/containers/landmark_measurement_container.hpp
@@ -171,7 +171,7 @@ class LandmarkMeasurementContainer {
      *
      * @return a vector of landmark IDs, in increasing order
      *
-     * If `start > end`, the result will be empty.
+     * The window is inclusive. If `start > end`, the result will be empty.
      */
     std::vector<LandmarkIdType> getLandmarkIDsInWindow(
       const TimeType &start, const TimeType &end) const;
@@ -188,7 +188,7 @@ class LandmarkMeasurementContainer {
      *
      * @return a vector of landmark measurements sorted by time
      *
-     * If `start >= end`, the result will be empty.
+     * The window is inclusive. If `start > end`, the result will be empty.
      */
     Track getTrackInWindow(const SensorIdType &s,
                            const LandmarkIdType &id,

--- a/wave_containers/tests/landmark_measurement_test.cpp
+++ b/wave_containers/tests/landmark_measurement_test.cpp
@@ -330,6 +330,15 @@ TEST_F(FilledLandmarkContainer, getTimeWindowSome) {
     }
 }
 
+TEST_F(FilledLandmarkContainer, getTimeWindowInstant) {
+    // Check case of window where `start == end`
+    const auto t = this->t_start + seconds(1);
+    auto res = this->m.getTimeWindow(t, t);
+
+    // Just ensure the result is not empty, don't worry about values here
+    EXPECT_EQ(1u, std::distance(res.first, res.second));
+}
+
 TEST_F(FilledLandmarkContainer, getLandmarkIDs) {
     auto ids = this->m.getLandmarkIDs();
 

--- a/wave_containers/tests/landmark_measurement_test.cpp
+++ b/wave_containers/tests/landmark_measurement_test.cpp
@@ -366,9 +366,10 @@ TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowEmpty) {
 TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowBackwards) {
     const auto t = this->t_start;
     // Check case of backwards window
-    auto ids = this->m.getLandmarkIDsInWindow(t + seconds(10), t);
+    auto ids = this->m.getLandmarkIDsInWindow(t + seconds(2), t);
     EXPECT_TRUE(ids.empty());
 }
+
 TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowAll) {
     // Check case of window containing all measurements
     const auto t = this->t_start;
@@ -392,6 +393,18 @@ TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowSome) {
     }
 }
 
+TEST_F(FilledLandmarkContainer, getLandmarkIdsInWindowInstant) {
+    const auto t = this->t_start + seconds(3);
+    // Check case of window where start == end.
+    // We expect it to return the landmarks at that instant
+    auto ids = this->m.getLandmarkIDsInWindow(t, t);
+    const auto expected = std::vector<LandmarkId>{2, 3, 4, 5};
+    ASSERT_EQ(expected.size(), ids.size());
+    for (auto i = 0u; i < ids.size(); ++i) {
+        EXPECT_EQ(expected[i], ids[i]);
+    }
+}
+
 TEST_F(FilledLandmarkContainer, getTrackInWindowEmpty) {
     // Check case of window with no measurements
     const auto t = this->t_start;
@@ -405,6 +418,14 @@ TEST_F(FilledLandmarkContainer, getTrackInWindowBackwards) {
     // Check case of backwards window
     auto track =
       this->m.getTrackInWindow(CameraSensors::Right, 4, t + seconds(10), t);
+    EXPECT_TRUE(track.empty());
+}
+
+TEST_F(FilledLandmarkContainer, getTrackInWindowInstant) {
+    const auto t = this->t_start + seconds(3);
+    // Check case where start == end
+    // Here (unlike in getLandmarkIDsInWindow) we expect empty result
+    auto track = this->m.getTrackInWindow(CameraSensors::Right, 4, t, t);
     EXPECT_TRUE(track.empty());
 }
 

--- a/wave_containers/tests/landmark_measurement_test.cpp
+++ b/wave_containers/tests/landmark_measurement_test.cpp
@@ -424,9 +424,13 @@ TEST_F(FilledLandmarkContainer, getTrackInWindowBackwards) {
 TEST_F(FilledLandmarkContainer, getTrackInWindowInstant) {
     const auto t = this->t_start + seconds(3);
     // Check case where start == end
-    // Here (unlike in getLandmarkIDsInWindow) we expect empty result
+    // We expect it to return a track of size 1, if there happens to be a
+    // measurement at that time point.
     auto track = this->m.getTrackInWindow(CameraSensors::Right, 4, t, t);
-    EXPECT_TRUE(track.empty());
+    ASSERT_EQ(1u, track.size());
+    EXPECT_EQ(t, track.front().time_point);
+    EXPECT_EQ(CameraSensors::Right, track.front().sensor_id);
+    EXPECT_EQ(4u, track.front().landmark_id);
 }
 
 TEST_F(FilledLandmarkContainer, getTrackInWindowAll) {

--- a/wave_containers/tests/measurement_test.cpp
+++ b/wave_containers/tests/measurement_test.cpp
@@ -272,6 +272,15 @@ TEST_F(FilledMeasurementContainer, getTimeWindowSome) {
     }
 }
 
+TEST_F(FilledMeasurementContainer, getTimeWindowInstant) {
+    // Check case of window where `start == end`
+    const auto t = this->t_start + seconds(1);
+    auto res = this->m.getTimeWindow(t, t);
+    ASSERT_EQ(2u, std::distance(res.first, res.second));
+    EXPECT_DOUBLE_EQ(3.4, res.first->value);
+    EXPECT_DOUBLE_EQ(25., (++res.first)->value);
+}
+
 TEST_F(FilledMeasurementContainer, getAllFromSensor) {
     // Check case of empty result
     auto res = this->m.getAllFromSensor(SomeSensors::S3);


### PR DESCRIPTION
Cover the edge case of `start == end` in the time window given to the functions `getTimeWindow()`, `getLandmarkIDsInWindow()` and `getTrackInWindow()`.

- Make all these functions treat an instantaneous time window as valid (return results if there happens to be something at the given time point).
- Add unit tests for this case
- Add notes to documentation

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
