### PR TITLE
Update Ceres and Eigen versions in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This library contains reusable code for:
 ## Requirements
 
 - Boost 1.54
-- Ceres 1.12
-- Eigen 3.2.0
+- Ceres 1.13
+- Eigen 3.3
 - Kindr 1.0.4
 - OpenCV 3.2.0
 - PCL 1.8

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library contains reusable code for:
 
 - Boost 1.54
 - Ceres 1.13
-- Eigen 3.3
+- Eigen 3.3.2
 - Kindr 1.0.4
 - OpenCV 3.2.0
 - PCL 1.8
@@ -22,6 +22,7 @@ This library contains reusable code for:
 - GCC 4.8
 
 The above versions are the minimum we test against.
+Some earlier minor versions may work, but are not tested.
 For convenience, we provide a script which installs these dependencies on
 Ubuntu 14.04 or Ubuntu 16.04, in `scripts/install/install_deps.bash`.
 


### PR DESCRIPTION
Resolves #193
Resolves #138

This commit reflects external work: I upgraded the ceres-solver and eigen3 packages in the ppa, [lkoppel/robotics](https://launchpad.net/~lkoppel/+archive/ubuntu/robotics), to 1.13.0rc1 and 3.3.2, respectively. They are now being used on travis.

These versions are not actually required for libwave right now, but future commits will depend on them. Those commits will update the version number enforced by `find_package(...)`, by which point everyone will have to upgrade.  Since the ReadMe simply lists what we test against, it can already be updated.

If you are already using the ppa, run `sudo apt update` and `sudo apt upgrade` to upgrade.

If you have another ceres installation is `/usr/local`, remove it. 
`sudo rm -r /usr/local/include/ceres /usr/local/lib/cmake/Ceres /usr/local/lib/libceres.*`


