### PR TITLE
Reorganize dataset files

### DIFF
--- a/wave_optimization/include/wave/optimization/ceres/ba.hpp
+++ b/wave_optimization/include/wave/optimization/ceres/ba.hpp
@@ -7,7 +7,7 @@
 
 #include "wave/utils/utils.hpp"
 #include "wave/vision/utils.hpp"
-#include "wave/vision/dataset.hpp"
+#include "wave/vision/dataset/VoDataset.hpp"
 
 namespace wave {
 

--- a/wave_optimization/tests/ceres/ba_test.cpp
+++ b/wave_optimization/tests/ceres/ba_test.cpp
@@ -1,6 +1,6 @@
 #include "wave/wave_test.hpp"
 #include "wave/utils/utils.hpp"
-#include "wave/vision/dataset.hpp"
+#include "wave/vision/dataset/VoDataset.hpp"
 #include "wave/optimization/ceres/ba.hpp"
 
 namespace wave {
@@ -62,7 +62,7 @@ TEST(BAResidual, constructor) {
 
 TEST(BAResidual, testResidual) {
     // create vo dataset
-    VOTestDatasetGenerator generator;
+    VoDatasetGenerator generator;
     generator.configure(TEST_CONFIG);
     auto dataset = generator.generate();
     LandmarkMap landmarks = dataset.landmarks;
@@ -97,7 +97,7 @@ TEST(BAResidual, testResidual) {
 
 TEST(BundleAdjustment, solve) {
     // create vo dataset
-    VOTestDatasetGenerator generator;
+    VoDatasetGenerator generator;
     generator.configure(TEST_CONFIG);
     auto dataset = generator.generate();
 

--- a/wave_vision/CMakeLists.txt
+++ b/wave_vision/CMakeLists.txt
@@ -27,7 +27,8 @@ ADD_LIBRARY(
     wave_vision
     STATIC
     src/utils.cpp
-    src/dataset.cpp
+    src/dataset/VoDataset.cpp
+    src/dataset/VoTestCamera.cpp
     src/detector/fast_detector.cpp
     src/detector/orb_detector.cpp
     src/descriptor/brisk_descriptor.cpp
@@ -44,7 +45,7 @@ WAVE_ADD_TEST(${PROJECT_NAME}_tests
               tests/descriptor_tests/orb_tests.cpp
               tests/matcher_tests/brute_force_tests.cpp
               tests/tracker_tests/tracker_tests.cpp
-              tests/dataset_tests.cpp
+              tests/dataset_tests/vo_dataset_tests.cpp
               tests/utils_tests.cpp)
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}_tests ${PROJECT_NAME})
 

--- a/wave_vision/include/wave/vision/dataset/VoDataset.hpp
+++ b/wave_vision/include/wave/vision/dataset/VoDataset.hpp
@@ -4,11 +4,11 @@
  * class.
  * @ingroup vision
  */
-#ifndef WAVE_VISION_DATASET_HPP
-#define WAVE_VISION_DATASET_HPP
+#ifndef WAVE_VISION_VODATASET_HPP
+#define WAVE_VISION_VODATASET_HPP
 
 #include "wave/utils/utils.hpp"
-#include "wave/vision/utils.hpp"
+#include "wave/vision/dataset/VoTestCamera.hpp"
 #include "wave/kinematics/two_wheel.hpp"
 #include "wave/containers/landmark_measurement.hpp"
 
@@ -16,63 +16,8 @@ namespace wave {
 /** @addtogroup vision
  *  @{ */
 
-/** Container for landmarks sorted by id */
-using LandmarkMap = std::map<LandmarkId, Vec3>;
-
-/** One observation of a landmark, in pixel coordinates */
-using LandmarkObservation = std::pair<LandmarkId, Vec2>;
-
-/** VO Test Camera that mimicks a real camera, specifically it contains:
- *
- * - Image width
- * - Image height
- * - Camera intrinsics matrix
- * - Camera update rate (Hz)
- * - Frame number
- *
- *  This class specifically is used to check whether 3D world features is
- *  observable by the camera in a certain position and orientation.
- */
-class VOTestCamera {
- public:
-    int image_width = 0;
-    int image_height = 0;
-    Mat3 K = Mat3::Identity();
-    double hz = 0.0;
-
-    double dt = 0.0;
-    int frame = 0;
-
-    VOTestCamera() {}
-
-    VOTestCamera(int image_width, int image_height, Mat3 K, double hz)
-        : image_width{image_width}, image_height{image_height}, K{K}, hz{hz} {}
-
-    /** Check whether camera is triggered at this time-step
-     * @returns boolean to denote true or false
-     */
-    bool update(double dt);
-
-    /** Gives a list of measurements of visible landmarks, if enough time has
-     * passed since the last frame
-     *
-     * @param dt Update time step
-     * @param landmarks map of landmarks with 3D position in world frame
-     * @param q_GC orientation of camera in global frame
-     * @param G_p_GC translation to camera from origin, in global frame
-     * @param observed Observed 3D features in the image frame
-     * @returns 0 if observations were made, 1 if not enough time passed
-     */
-    int observeLandmarks(double dt,
-                         const LandmarkMap &landmarks,
-                         const Quaternion &q_GC,
-                         const Vec3 &G_p_GC,
-                         std::vector<LandmarkObservation> &observed);
-};
-
-
 /** A set of feature observations at one timestep */
-struct VOTestInstant {
+struct VoInstant {
     /** A time in nominal seconds */
     double time;
 
@@ -98,13 +43,13 @@ struct VOTestInstant {
  * - 3D Features in the world (landmark ground truth)
  * - 3D Features observed in image frame on the two wheel robot
  */
-struct VOTestDataset {
+struct VoDataset {
     /** Ground truth 3D world features, where each column represents a feature
      * and each row represents the landmark position in x, y, z (NWU)  */
     LandmarkMap landmarks;
 
     /** For each time step, a set of measurements */
-    std::vector<VOTestInstant> states;
+    std::vector<VoInstant> states;
 
     /** Pinhole camera intrinsic calibration matrix */
     Mat3 camera_K;
@@ -182,16 +127,16 @@ struct VOTestDataset {
      *
      * @todo: add error checking
      */
-    static VOTestDataset loadFromDirectory(const std::string &input_dir);
+    static VoDataset loadFromDirectory(const std::string &input_dir);
 };
 
 /**
  * Synthetic VO dataset generator.
  *
  * This class simulates a two wheel robot traversing in circle where the world
- * has 3D random feature points, and stores the data in a VOTestDataset object.
+ * has 3D random feature points, and stores the data in a VoTestDataset object.
  */
-class VOTestDatasetGenerator {
+class VoDatasetGenerator {
  public:
     void configure(const std::string &config_file);
 
@@ -203,20 +148,20 @@ class VOTestDatasetGenerator {
     LandmarkMap generateLandmarks();
 
     /** Simulates a two wheel robot traversing in a world with random 3D feature
-     * points, and records:
-     *
-     * - Robot pose (robot ground truth)
-     * - 3D Features in the world (landmark ground truth)
-     * - 3D Features observed in image frame on the two wheel robot
-     *
-     * in a VOTestDataset object.
-     *
-     * A measurement including robot pose is stored at every timestep (with an
-     * arbitrary dt), but feature observations are only made at some timesteps.
-     */
-    VOTestDataset generate();
+ * points, and records:
+ *
+ * - Robot pose (robot ground truth)
+ * - 3D Features in the world (landmark ground truth)
+ * - 3D Features observed in image frame on the two wheel robot
+ *
+ * in a VoTestDataset object.
+ *
+ * A measurement including robot pose is stored at every timestep (with an
+ * arbitrary dt), but feature observations are only made at some timesteps.
+ */
+    VoDataset generate();
 
-    VOTestCamera camera;
+    VoTestCamera camera;
     int nb_landmarks = 0;
     Vec2 landmark_x_bounds = Vec2::Zero();
     Vec2 landmark_y_bounds = Vec2::Zero();
@@ -225,4 +170,4 @@ class VOTestDatasetGenerator {
 
 /** @} end of group */
 }  // namespace wave
-#endif
+#endif  // WAVE_VISION_VODATASET_HPP

--- a/wave_vision/include/wave/vision/dataset/VoTestCamera.hpp
+++ b/wave_vision/include/wave/vision/dataset/VoTestCamera.hpp
@@ -5,9 +5,6 @@
 #ifndef WAVE_VISION_VOTESTCAMERA_HPP
 #define WAVE_VISION_VOTESTCAMERA_HPP
 
-#include <sys/stat.h>
-#include <sys/types.h>
-
 #include "wave/utils/utils.hpp"
 #include "wave/vision/utils.hpp"
 #include "wave/kinematics/two_wheel.hpp"

--- a/wave_vision/include/wave/vision/dataset/VoTestCamera.hpp
+++ b/wave_vision/include/wave/vision/dataset/VoTestCamera.hpp
@@ -1,0 +1,77 @@
+/**
+ * @file
+ * @ingroup vision
+ */
+#ifndef WAVE_VISION_VOTESTCAMERA_HPP
+#define WAVE_VISION_VOTESTCAMERA_HPP
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "wave/utils/utils.hpp"
+#include "wave/vision/utils.hpp"
+#include "wave/kinematics/two_wheel.hpp"
+#include "wave/containers/landmark_measurement.hpp"
+
+namespace wave {
+/** @addtogroup vision
+ *  @{ */
+
+/** Container for landmarks sorted by id */
+using LandmarkMap = std::map<LandmarkId, Vec3>;
+
+/** One observation of a landmark, in pixel coordinates */
+using LandmarkObservation = std::pair<LandmarkId, Vec2>;
+
+/** VO Test Camera that mimicks a real camera, specifically it contains:
+ *
+ * - Image width
+ * - Image height
+ * - Camera intrinsics matrix
+ * - Camera update rate (Hz)
+ * - Frame number
+ *
+ *  This class specifically is used to check whether 3D world features is
+ *  observable by the camera in a certain position and orientation.
+ */
+class VoTestCamera {
+ public:
+    int image_width = 0;
+    int image_height = 0;
+    Mat3 K = Mat3::Identity();
+    double hz = 0.0;
+
+    double dt = 0.0;
+    int frame = 0;
+
+    VoTestCamera() {}
+
+    VoTestCamera(int image_width, int image_height, Mat3 K, double hz)
+        : image_width{image_width}, image_height{image_height}, K{K}, hz{hz} {}
+
+    /** Check whether camera is triggered at this time-step
+     * @returns boolean to denote true or false
+     */
+    bool update(double dt);
+
+    /** Gives a list of measurements of visible landmarks, if enough time has
+     * passed since the last frame
+     *
+     * @param dt Update time step
+     * @param landmarks map of landmarks with 3D position in world frame
+     * @param q_GC orientation of camera in global frame
+     * @param G_p_GC translation to camera from origin, in global frame
+     * @param observed Observed 3D features in the image frame
+     * @returns 0 if observations were made, 1 if not enough time passed
+     */
+    int observeLandmarks(double dt,
+                         const LandmarkMap &landmarks,
+                         const Quaternion &q_GC,
+                         const Vec3 &G_p_GC,
+                         std::vector<LandmarkObservation> &observed);
+};
+
+
+/** @} end of group */
+}  // namespace wave
+#endif  // WAVE_VISION_VOTESTCAMERA_HPP

--- a/wave_vision/src/dataset/VoDataset.cpp
+++ b/wave_vision/src/dataset/VoDataset.cpp
@@ -2,6 +2,8 @@
 
 #include "wave/vision/dataset/VoDataset.hpp"
 
+#include <sys/stat.h>
+
 namespace wave {
 
 void VoDatasetGenerator::configure(const std::string &config_file) {

--- a/wave_vision/src/dataset/VoTestCamera.cpp
+++ b/wave_vision/src/dataset/VoTestCamera.cpp
@@ -1,0 +1,50 @@
+#include "wave/vision/dataset/VoTestCamera.hpp"
+
+namespace wave {
+
+
+bool VoTestCamera::update(double dt) {
+    this->dt += dt;
+
+    if (this->dt > (1.0 / this->hz)) {
+        this->dt = 0.0;
+        this->frame++;
+        return true;
+    }
+
+    return false;
+}
+
+int VoTestCamera::observeLandmarks(double dt,
+                                   const LandmarkMap &landmarks,
+                                   const Quaternion &q_GC,
+                                   const Vec3 &G_p_GC,
+                                   std::vector<LandmarkObservation> &observed) {
+    // pre-check
+    if (this->update(dt) == false) {
+        return 1;
+    }
+
+    // get rotation matrix from world frame to camera frame
+    Mat3 R_GC = q_GC.matrix();
+
+    // check which landmarks in 3d are observable from camera
+    observed.clear();
+    for (auto landmark : landmarks) {
+        const auto &point = landmark.second;
+
+        // project 3D world point to 2D image plane, also checking cheirality
+        Vec2 meas;
+        auto in_front = pinholeProject(this->K, R_GC, G_p_GC, point, meas);
+        if (in_front) {
+            // check to see if feature observed is within image plane
+            if (meas.x() < this->image_width && meas.x() > 0 &&
+                meas.y() < this->image_height && meas.y() > 0) {
+                observed.emplace_back(landmark.first, meas);
+            }
+        }
+    }
+    return 0;
+}
+
+}  // namespace wave

--- a/wave_vision/tests/dataset_tests/vo_dataset_tests.cpp
+++ b/wave_vision/tests/dataset_tests/vo_dataset_tests.cpp
@@ -1,13 +1,13 @@
 #include "wave/wave_test.hpp"
-#include "wave/vision/dataset.hpp"
+#include "wave/vision/dataset/VoDataset.hpp"
 
 namespace wave {
 
 const std::string TEST_CONFIG = "tests/data/vo_test.yaml";
 const std::string TEST_OUTPUT = "/tmp/dataset_test";
 
-TEST(VOTestCamera, constructor) {
-    VOTestCamera camera;
+TEST(VoTestCamera, constructor) {
+    VoTestCamera camera;
 
     EXPECT_EQ(0, camera.image_width);
     EXPECT_EQ(0, camera.image_height);
@@ -18,8 +18,8 @@ TEST(VOTestCamera, constructor) {
     EXPECT_EQ(0, camera.frame);
 }
 
-TEST(VOTestCamera, update) {
-    VOTestCamera camera;
+TEST(VoTestCamera, update) {
+    VoTestCamera camera;
     bool retval;
 
     // setup
@@ -32,7 +32,7 @@ TEST(VOTestCamera, update) {
     EXPECT_FLOAT_EQ(0.0, camera.dt);
 }
 
-TEST(VOTestCamera, observeLandmarks) {
+TEST(VoTestCamera, observeLandmarks) {
     // setup
     Vec3 G_p_GC{0, 0, 0};
 
@@ -47,7 +47,7 @@ TEST(VOTestCamera, observeLandmarks) {
     landmarks.emplace(3, Vec3{5.0, 0.2, 1.3});    // above and to the left
     landmarks.emplace(4, Vec3{1.0, 223.0, -19});  // in front, but far off
 
-    VOTestCamera camera;
+    VoTestCamera camera;
     camera.hz = 60;
     camera.image_width = 640;
     camera.image_height = 640;
@@ -68,15 +68,14 @@ TEST(VOTestCamera, observeLandmarks) {
     EXPECT_LT(observed[1].second.y(), 320);
 }
 
-TEST(VOTestDataset, constructor) {
-    VOTestDatasetGenerator dataset;
-
+TEST(VoDataset, constructor) {
+    VoDatasetGenerator dataset;
     EXPECT_EQ(0, dataset.camera.image_width);
     EXPECT_EQ(0, dataset.camera.image_height);
 }
 
-TEST(VOTestDataset, configure) {
-    VOTestDatasetGenerator dataset;
+TEST(VoDataset, configure) {
+    VoDatasetGenerator dataset;
 
     EXPECT_NO_THROW(dataset.configure(TEST_CONFIG));
 
@@ -88,19 +87,18 @@ TEST(VOTestDataset, configure) {
     EXPECT_FLOAT_EQ(0.0, dataset.camera.K(2, 1));
 }
 
-TEST(VOTestDataset, generate) {
-    VOTestDatasetGenerator generator;
-
+TEST(VoDataset, generate) {
+    VoDatasetGenerator generator;
     generator.configure(TEST_CONFIG);
     auto dataset = generator.generate();
 }
 
-TEST(VOTestDataset, writeAndReadToFile) {
+TEST(VoDataset, writeAndReadToFile) {
     // To test both operations, we write to files, read them, and ensure the
     // resulting dataset is the one we started with
     const auto tol = 1e-5;  // Required precision for Eigen's isApprox
 
-    VOTestDatasetGenerator generator;
+    VoDatasetGenerator generator;
 
     remove_dir(TEST_OUTPUT);
     generator.configure(TEST_CONFIG);
@@ -110,7 +108,7 @@ TEST(VOTestDataset, writeAndReadToFile) {
     dataset.outputToDirectory(TEST_OUTPUT);
 
     // Read
-    auto input = VOTestDataset::loadFromDirectory(TEST_OUTPUT);
+    auto input = VoDataset::loadFromDirectory(TEST_OUTPUT);
 
     EXPECT_EQ(dataset.camera_K, input.camera_K);
     for (const auto &l : dataset.landmarks) {


### PR DESCRIPTION
_Do not merge, the base is not master_

- Move VO dataset files to separate dataset directory
  (This is preparing for a second, VIO, dataset)
- Rename dataset.hpp -> VoDataset.hpp
- Rename VOTestDataset -> VoDataset
- Move VoTestCamera to separate file
- Remove unneeded includes

No functional changes.


#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
