### PR TITLE
Increase GCC version to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 dist: trusty
 sudo: false
 
-language: cpp
+language: generic  # don't use the default compilers for "cpp"
 
 cache:
   ccache: true
 
+env:
+  CXX='ccache g++-5' CC='ccache gcc-5'
+
 addons:
   apt:
     sources:
+      - ubuntu-toolchain-r-test
       - sourceline: 'ppa:lkoppel/robotics'
     packages:
+      - g++-5
       - libboost-dev
       - libyaml-cpp-dev
       - libeigen3-dev

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This library contains reusable code for:
 - PCL 1.8
 - yaml-cpp 0.5.1
 - CMake 2.8.3
-- GCC 4.8
+- GCC 5.4
 
 The above versions are the minimum we test against.
-Some earlier minor versions may work, but are not tested.
-For convenience, we provide a script which installs these dependencies on
-Ubuntu 14.04 or Ubuntu 16.04, in `scripts/install/install_deps.bash`.
+Some earlier versions may work, but are not tested.
+For convenience, we provide a script which installs these dependencies (except 
+GCC) on Ubuntu 14.04 or Ubuntu 16.04, in `scripts/install/install_deps.bash`.
 
 ## Install
 

--- a/wave_utils/include/wave/utils/math.hpp
+++ b/wave_utils/include/wave/utils/math.hpp
@@ -12,6 +12,7 @@
 #define WAVE_UTILS_MATH_HPP
 
 #include <iostream>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <Eigen/Geometry>


### PR DESCRIPTION
Resolves #150

Increase GCC requirement and travis version to 5.4.

I suspect 5.0 or 5.1 would work but that is harder to test. 5.4 is the version on Ubuntu 16.04.

#### Pre-Merge Checklist:
- [x] Zero compiler warnings
