### PR TITLE
Fix travis build caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 dist: trusty
 sudo: false
 
-language: generic  # don't use the default compilers for "cpp"
+language: cpp
 
 cache:
   ccache: true
-
-env:
-  CXX='ccache g++-5' CC='ccache gcc-5'
 
 addons:
   apt:
@@ -26,9 +23,10 @@ addons:
       - clang-format-3.8
 
 before_script:
-  - bash scripts/ci/ci_check.bash
+  - export CXX=g++-5 CC=gcc-5  # override travis defaults
 
 script:
+  - bash scripts/ci/ci_check.bash
   - bash scripts/ci/ci_run.bash
 
 notifications:


### PR DESCRIPTION
Travis requires the language to be "cpp" to save the travis cache. Fix the setting of the compiler variables so we can both use gcc-5 and have the cache.