### PR TITLE
Fix Eigen alignment issue with Matcher

### DIFF
--- a/wave_matching/include/wave/matching/matcher.hpp
+++ b/wave_matching/include/wave/matching/matcher.hpp
@@ -31,6 +31,7 @@ class ConfigException : public __exception {
 template <typename T>
 class Matcher {
  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     /** This constructor takes an argument in order to adjust how much
      * downsampling is done before matching is attempted. Pointclouds are
      * downsampled using a voxel filter.

--- a/wave_matching/include/wave/matching/multi_matcher.hpp
+++ b/wave_matching/include/wave/matching/multi_matcher.hpp
@@ -80,7 +80,7 @@ class MultiMatcher {
     std::queue<std::tuple<int, PCLPointCloud, PCLPointCloud>> input;
     std::queue<std::tuple<int, Eigen::Affine3d, Mat6>> output;
     std::vector<std::thread> pool;
-    std::vector<T> matchers;
+    std::vector<T, Eigen::aligned_allocator<T>> matchers;
 
     // Synchronization
     std::mutex ip_mutex, op_mutex, cnt_mutex;


### PR DESCRIPTION
I was seeing a sefault in MultiTests.initialization, which went away with this change.

See https://eigen.tuxfamily.org/dox/group__DenseMatrixManipulation__Alignement.html

Note I only fixed one instance that was causing a crash; more changes must be made elsewhere. Related: #139
