### PR TITLE
Add benchmarks to MeasurementContainer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,7 @@ INCLUDE(cmake/ImportBoost.cmake)
 INCLUDE(cmake/ImportPCL.cmake)
 INCLUDE(cmake/ImportKindr.cmake)
 
-
-# Download and build benchmark library, if benchmarks enabled
+# Optionally build benchmarks (requires `benchmark` package to be installed)
 IF(BUILD_BENCHMARKS)
     FIND_PACKAGE(benchmark REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ OPTION(BUILD_SHARED_LIBS "Build shared instead of static libraries" OFF)
 OPTION(EXPORT_BUILD
  "Add this build directory to CMake's user package registry.\
  Allows the package to be found without install." OFF)
+OPTION(BUILD_BENCHMARKS
+    "Build benchmarks for some components. Requires google benchmark package."
+    OFF)
+
 
 # Find common dependencies (used by multiple required modules)
 
@@ -38,6 +42,19 @@ INCLUDE(cmake/ImportEigen3.cmake)
 INCLUDE(cmake/ImportBoost.cmake)
 INCLUDE(cmake/ImportPCL.cmake)
 INCLUDE(cmake/ImportKindr.cmake)
+
+
+# Download and build benchmark library, if benchmarks enabled
+IF(BUILD_BENCHMARKS)
+    FIND_PACKAGE(benchmark REQUIRED)
+
+    STRING(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
+    IF(NOT build_type MATCHES rel)
+        MESSAGE(WARNING "Building benchmarks but not in Release mode."
+            " (CMAKE_BUILD_TYPE=\"${CMAKE_BUILD_TYPE}\")\n"
+            "Benchmark results might not be useful.")
+    ENDIF()
+ENDIF(BUILD_BENCHMARKS)
 
 # Add a special "wave" target including all modules
 # The WAVE_ADD_LIBRARY helper in WaveUtils.cmake will add each module to this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,12 @@ IF(BUILD_BENCHMARKS)
             " (CMAKE_BUILD_TYPE=\"${CMAKE_BUILD_TYPE}\")\n"
             "Benchmark results might not be useful.")
     ENDIF()
+
+    # This target is used to run benchmarks via "make benchmark".
+    # Like "make test", it does not build anything. (@todo change?)
+    # It runs all tests labelled "benchmark" by WAVE_ADD_BENCHMARK helper.
+    ADD_CUSTOM_TARGET(benchmark
+         COMMAND ${CMAKE_CTEST_COMMAND} -C benchmark -L benchmark)
 ENDIF(BUILD_BENCHMARKS)
 
 # Add a special "wave" target including all modules

--- a/cmake/WaveUtils.cmake
+++ b/cmake/WaveUtils.cmake
@@ -40,6 +40,24 @@ FUNCTION(WAVE_ADD_TEST NAME)
 
 ENDFUNCTION(WAVE_ADD_TEST)
 
+# wave_add_benchmark: Add a target which links against google benchmark
+#
+# WAVE_ADD_BENCHMARK(Name src1 [src2...])
+#
+# The target will be added to the tests run by "make benchmark". It will be
+# linked against the needed libraries. Any other links can be made separately
+# with the target_link_libraries command.
+FUNCTION(WAVE_ADD_BENCHMARK NAME)
+    # Build the executable using the given sources
+    ADD_EXECUTABLE(${NAME} ${ARGN})
+
+    TARGET_LINK_LIBRARIES(${NAME} benchmark::benchmark)
+
+    # Put the executable in the benchmarks/ directory
+    SET_TARGET_PROPERTIES(${NAME} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/benchmarks)
+ENDFUNCTION(WAVE_ADD_BENCHMARK)
+
 # wave_include_directories: Set a module's include paths so they are usable
 # from both the build and install tree
 #

--- a/cmake/WaveUtils.cmake
+++ b/cmake/WaveUtils.cmake
@@ -56,6 +56,13 @@ FUNCTION(WAVE_ADD_BENCHMARK NAME)
     # Put the executable in the benchmarks/ directory
     SET_TARGET_PROPERTIES(${NAME} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/benchmarks)
+
+    # Add a ctest that will not be run by default.
+    # To run it the command `ctest -C benchmark -L benchmark` must be used.
+    # (Setting -C excludes it from the default set, and setting -L excludes the
+    # default tests from it). Note the target `benchmark` runs this command.
+    ADD_TEST(NAME ${NAME} COMMAND ${NAME} CONFIGURATIONS benchmark)
+    SET_TESTS_PROPERTIES(${NAME} PROPERTIES LABELS benchmark)
 ENDFUNCTION(WAVE_ADD_BENCHMARK)
 
 # wave_include_directories: Set a module's include paths so they are usable

--- a/wave_containers/CMakeLists.txt
+++ b/wave_containers/CMakeLists.txt
@@ -13,3 +13,9 @@ WAVE_ADD_TEST(${PROJECT_NAME}_tests
     tests/landmark_measurement_test.cpp)
 
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}_tests ${PROJECT_NAME})
+
+IF(BUILD_BENCHMARKS)
+    WAVE_ADD_BENCHMARK(${PROJECT_NAME}_benchmark
+        tests/measurement_container_benchmark.cpp)
+    TARGET_LINK_LIBRARIES(${PROJECT_NAME}_benchmark ${PROJECT_NAME})
+ENDIF(BUILD_BENCHMARKS)

--- a/wave_containers/tests/measurement_container_benchmark.cpp
+++ b/wave_containers/tests/measurement_container_benchmark.cpp
@@ -1,0 +1,4 @@
+#include <benchmark/benchmark.h>
+
+
+BENCHMARK_MAIN();

--- a/wave_containers/tests/measurement_container_benchmark.cpp
+++ b/wave_containers/tests/measurement_container_benchmark.cpp
@@ -1,4 +1,135 @@
 #include <benchmark/benchmark.h>
+#include <Eigen/Core>
+#include <iostream>
+#include <unordered_map>
+#include "wave/containers/measurement_container.hpp"
 
+namespace wave {
+
+/** A simple measurement type used for this benchmark */
+struct TestMeas {
+    int time_point;
+    int sensor_id;
+    double value;
+
+    TestMeas() = default;
+    TestMeas(int t, int s, double v) : time_point{t}, sensor_id{s}, value{v} {}
+};
+
+/** The corresponding interpolate function, required by MeasurementContainer */
+double interpolate(const TestMeas &m1, const TestMeas &m2, const double &t) {
+    auto w2 = 1.0 * (t - m1.time_point) / (m2.time_point - m1.time_point);
+    return (1 - w2) * m1.value + w2 * m2.value;
+}
+
+/** Returns a random double. */
+double random(double start = 0, double end = 1) {
+    // To avoid doing any work use Eigen's implementation
+    return Eigen::internal::random<double>(start, end);
+}
+
+/** A bare bones boost::multi_index_container type, with only one index. It is
+ * here to serve as a baseline against which to compare  MeasurementContainer.
+ * It was also helpful as a sanity check while writing the benchmarks
+ * themselves, since the complexity of its operations is known.
+ */
+using BaselineMIC = boost::multi_index_container<
+  TestMeas,
+  boost::multi_index::indexed_by<boost::multi_index::ordered_unique<
+    boost::multi_index::member<TestMeas, int, &TestMeas::time_point>>>,
+  std::allocator<TestMeas>>;
+
+/** Makes a container with `n` sequential TestMeas elements */
+template <typename T>
+T makeContainer(int n) {
+    auto container = T{};
+    for (int i = 0; i < n; ++i) {
+        container.emplace(i, 0, random());
+    }
+    return container;
+}
+
+/** Test emplacing an element at the end of the container */
+template <typename T>
+void BM_ContainerEmplace(benchmark::State &state) {
+    const auto size = state.range(0);
+
+    // Prepare a container of the size given by BM
+    auto container = makeContainer<T>(size);
+    for (auto _ : state) {
+        state.PauseTiming();
+        // Restore the container to the original size
+        for (auto it = container.end();
+             container.size() > static_cast<std::size_t>(size);) {
+            container.erase(--it);
+        }
+        auto t = size + 1;
+        state.ResumeTiming();
+
+        // Perform actual timed operations
+        for (int j = 0; j < state.range(1); ++j) {
+            container.emplace(t++, 0, random());
+        }
+    }
+
+    // Use this benchmark to caculate big O complexity
+    state.SetComplexityN(size);
+}
+
+/** Test finding an element in the baseline container */
+void BM_BaselineGet(benchmark::State &state) {
+    const auto size = state.range(0);
+
+    // Prepare a container of the size given by BM
+    auto container = makeContainer<BaselineMIC>(size);
+
+    for (auto _ : state) {
+        // Request an element with a random time_point
+        auto t = static_cast<int>(std::floor(random(0, size)));
+        const auto res = container.find(t);
+        benchmark::DoNotOptimize(res);
+    }
+
+    // Use this benchmark to caculate big O complexity
+    state.SetComplexityN(size);
+}
+
+/** Test finding an element in the MeasurementContainer
+ *
+ * Note this is not a templated benchmark due to API differences between the
+ * baseline MIC and MeasurementContainer.
+ */
+void BM_ContainerGet(benchmark::State &state) {
+    const auto size = state.range(0);
+
+    // Prepare a container of the size given by BM
+    auto container = makeContainer<MeasurementContainer<TestMeas>>(size);
+
+    for (auto _ : state) {
+        // Request an element with a random time_point
+        auto t = static_cast<int>(std::floor(random(0, size)));
+        auto res = container.get(t, 0);
+        benchmark::DoNotOptimize(res);
+    }
+
+    // Use this benchmark to caculate big O complexity
+    state.SetComplexityN(size);
+}
+
+// Configure the benchmarks to run
+
+BENCHMARK_TEMPLATE(BM_ContainerEmplace, BaselineMIC)
+  ->Ranges({{1 << 15, 1 << 20}, {1, 10}})
+  ->Complexity();
+
+BENCHMARK_TEMPLATE(BM_ContainerEmplace, MeasurementContainer<TestMeas>)
+  ->Ranges({{1 << 15, 1 << 20}, {1, 10}})
+  ->Complexity();
+
+BENCHMARK(BM_BaselineGet)->Range(1 << 12, 1 << 22)->Complexity();
+
+BENCHMARK(BM_ContainerGet)->Range(1 << 8, 1 << 18)->Complexity();
+
+}  // namespace wave
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Part of #227 

- Add CMake helpers to add benchmarks using Google's benchmark library
- Add benchmarks investigate MeasurementContainer performance (empalce() and get())

To build them, you must install [benchmark](https://github.com/google/benchmark/), then build libwave with `cmake .. -DBUILD_BENCHMARKS=ON`. 

benchmark is similar to gtest in how the tests are defined; that's part of why I chose it.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [ ] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`

These benchmarks are currently not built on Travis. They require an extra library and take pretty long to run. Conceivably in the future we could have a separate benchmarking build on Travis, but it's not a priority.