### PR TITLE
Improve MeasurementContainer::get() performance

### DIFF
--- a/wave_containers/include/wave/containers/impl/measurement_container.hpp
+++ b/wave_containers/include/wave/containers/impl/measurement_container.hpp
@@ -139,7 +139,9 @@ typename MeasurementContainer<T>::ValueType MeasurementContainer<T>::get(
 
     if (i_next == sensor_index.end() || i_next->sensor_id != s) {
         // Requested time is not between two measurements for this sensor
-        throw std::out_of_range("MeasurementContainer::get");
+        throw std::out_of_range{
+          "MeasurementContainer::get: "
+          "requested time is after last measurement for sensor"};
     }
 
     if (t == i_next->time_point) {
@@ -150,7 +152,9 @@ typename MeasurementContainer<T>::ValueType MeasurementContainer<T>::get(
     // If no exact match, need at least one previous measurement to interpolate
     if (i_next == sensor_index.begin() || std::prev(i_next)->sensor_id != s) {
         // Requested time is not between two measurements for this sensor
-        throw std::out_of_range("MeasurementContainer::get");
+        throw std::out_of_range{
+          "MeasurementContainer::get: "
+          "requested time is before first measurement for sensor"};
     }
 
     // Requested time is between two applicable measurements. Can interpolate.

--- a/wave_containers/include/wave/containers/impl/measurement_container.hpp
+++ b/wave_containers/include/wave/containers/impl/measurement_container.hpp
@@ -148,16 +148,14 @@ typename MeasurementContainer<T>::ValueType MeasurementContainer<T>::get(
     }
 
     // If no exact match, need at least one previous measurement to interpolate
-    const auto i_prev = std::prev(i_next);
-
-    if (i_next == sensor_index.begin() || i_prev->sensor_id != s) {
+    if (i_next == sensor_index.begin() || std::prev(i_next)->sensor_id != s) {
         // Requested time is not between two measurements for this sensor
         throw std::out_of_range("MeasurementContainer::get");
     }
 
     // Requested time is between two applicable measurements. Can interpolate.
     // Get pointer to the first element < t (since keys are unique)
-    return interpolate(*i_prev, *i_next, t);
+    return interpolate(*std::prev(i_next), *i_next, t);
 }
 
 template <typename T>

--- a/wave_containers/include/wave/containers/impl/measurement_container.hpp
+++ b/wave_containers/include/wave/containers/impl/measurement_container.hpp
@@ -11,7 +11,6 @@ namespace internal {
 using boost::multi_index::member;
 using boost::multi_index::indexed_by;
 using boost::multi_index::ordered_unique;
-using boost::multi_index::ordered_non_unique;
 using boost::multi_index::composite_key;
 using boost::multi_index::tag;
 
@@ -39,22 +38,21 @@ struct measurement_container {
     // Specify that the sensor key corresponds to the sensor_id member
     struct sensor_key : member<T, decltype(T::sensor_id), &T::sensor_id> {};
 
-    // Define a composite key which combines the above two keys
-    // This lets us search elements sorted by time first, then  sensor id
-    struct sensor_and_time_key : composite_key<T, time_key, sensor_key> {};
+    // Define a composite key sorted by time first, then sensor
+    struct time_and_sensor_key : composite_key<T, time_key, sensor_key> {};
+
+    // Define a composite key sorted by sensor first, then time
+    struct sensor_and_time_key : composite_key<T, sensor_key, time_key> {};
 
     // These types are used as tags to retrieve each index after the
     // multi_index_container is generated
-    struct time_index {};
     struct sensor_index {};
     struct composite_index {};
 
     // Define an index for each key. Each index will be accessible via its tag
     struct indices
-      : indexed_by<ordered_non_unique<tag<time_index>, time_key>,
-                   ordered_non_unique<tag<sensor_index>, sensor_key>,
-                   ordered_unique<tag<composite_index>, sensor_and_time_key>> {
-    };
+      : indexed_by<ordered_unique<tag<composite_index>, time_and_sensor_key>,
+                   ordered_unique<tag<sensor_index>, sensor_and_time_key>> {};
 
     // Note we use separate struct definitions above, instead of typedefs, to
     // reduce the length of the name printed by the compiler.
@@ -66,13 +64,6 @@ struct measurement_container {
     // For convenience, get the type of some indices, using their tags
     using composite_type = typename type::template index<composite_index>::type;
     using sensor_type = typename type::template index<sensor_index>::type;
-
-
-    // Define a view indexed by time, for complex searches
-    struct const_time_index
-      : indexed_by<ordered_unique<
-          member<T, const decltype(T::time_point), &T::time_point>>> {};
-    using time_view = boost::multi_index_container<const T *, const_time_index>;
 };
 }  // namespace internal
 
@@ -138,48 +129,35 @@ typename MeasurementContainer<T>::iterator MeasurementContainer<T>::erase(
 template <typename T>
 typename MeasurementContainer<T>::ValueType MeasurementContainer<T>::get(
   const TimeType &t, const SensorIdType &s) const {
-    // To interpolate measurements from one sensor only, we first extract all
-    // measurements from that sensor, then search by time. This method is based
-    // on one described here:
-    // http://www.boost.org/doc/libs/1_63_0/libs/multi_index/doc/examples.html#example6
-
-    // Find all measurements from this sensor
+    // To interpolate measurements from one sensor only, we use the index sorted
+    // by sensor_id first
     const auto &sensor_index = this->storage.template get<
       typename internal::measurement_container<T>::sensor_index>();
-    const auto sensor_it = sensor_index.equal_range(s);
 
-    // Construct a view, indexed by time, with only those measurements
-    auto time_view = typename internal::measurement_container<T>::time_view{};
-    for (auto it = sensor_it.first; it != sensor_it.second; ++it) {
-        time_view.insert(&*it);  // the view holds pointers to the measurements
-    }
+    // find the first element with sensor>=s and time >= t
+    auto i_next = sensor_index.lower_bound(boost::make_tuple(s, t));
 
-    // find the first element with time >= t
-    auto i_next = time_view.lower_bound(t);
-
-    if (i_next == time_view.end()) {
+    if (i_next == sensor_index.end() || i_next->sensor_id != s) {
         // Requested time is not between two measurements for this sensor
         throw std::out_of_range("MeasurementContainer::get");
     }
 
-    const auto p_next = *i_next;
-
-    if (t == p_next->time_point) {
+    if (t == i_next->time_point) {
         // Requested time exactly matches
-        return p_next->value;
+        return i_next->value;
     }
 
-    // If no exact match, need at least one more measurement to interpolate
-    if (i_next == time_view.begin()) {
+    // If no exact match, need at least one previous measurement to interpolate
+    const auto i_prev = std::prev(i_next);
+
+    if (i_next == sensor_index.begin() || i_prev->sensor_id != s) {
         // Requested time is not between two measurements for this sensor
         throw std::out_of_range("MeasurementContainer::get");
     }
 
     // Requested time is between two applicable measurements. Can interpolate.
     // Get pointer to the first element < t (since keys are unique)
-    const auto i_prev = std::prev(i_next);
-    const auto p_prev = *i_prev;
-    return interpolate(*p_prev, *p_next, t);
+    return interpolate(*i_prev, *i_next, t);
 }
 
 template <typename T>

--- a/wave_containers/tests/measurement_container_benchmark.cpp
+++ b/wave_containers/tests/measurement_container_benchmark.cpp
@@ -126,9 +126,9 @@ BENCHMARK_TEMPLATE(BM_ContainerEmplace, MeasurementContainer<TestMeas>)
   ->Ranges({{1 << 15, 1 << 20}, {1, 10}})
   ->Complexity();
 
-BENCHMARK(BM_BaselineGet)->Range(1 << 12, 1 << 22)->Complexity();
+BENCHMARK(BM_BaselineGet)->Range(1 << 15, 1 << 22)->Complexity();
 
-BENCHMARK(BM_ContainerGet)->Range(1 << 8, 1 << 18)->Complexity();
+BENCHMARK(BM_ContainerGet)->Range(1 << 15, 1 << 22)->Complexity();
 
 }  // namespace wave
 


### PR DESCRIPTION
Part of #227

The benchmarks added in #228 show `emplace()` performance is as expected, but `get()` is much slower than expected: O(NlogN) instead of O(logN).

Refactor the MeasurementContainer internals to remove the problem. As a bonus the new implementation is a bit simpler.

Details:
> Change the internal indexing of the multi_index_container: add a sensor-first
    composite index.
    Use this sensor-first composite index in get() instead of creating a view,
    which was really inefficient.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
