### PR TITLE
Fix copyright notice in ReadMe

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Wavelab
+Copyright (c) 2017 Waterloo Autonomous Vehicles Laboratory (WAVELab)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) <2017> <Wavelab>
+Copyright (c) 2017 Wavelab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ these can be activated by running the `githook_init.bash` from the root of the r
 
 ## LICENSE
 
-Copyright (c) 2017 Wavelab
+Copyright (c) 2017 Waterloo Autonomous Vehicles Laboratory (WAVELab)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ these can be activated by running the `githook_init.bash` from the root of the r
 
 ## LICENSE
 
-Copyright (c) <2017> <Wavelab>
+Copyright (c) 2017 Wavelab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The angle brackets were making &lt;Wavelab&gt; invisible on github.

- Remove angle brackets
- Write out full name