### PR TITLE
Add package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,15 @@
+<package format="2">
+  <name>libwave</name>
+  <version>0.1.0</version>
+  <description>libwave</description>
+
+  <maintainer email="chutsu@gmail.com">Chris Choi</maintainer>
+  <maintainer email="lkoppel@uwaterloo.ca">Leo Koppel</maintainer>
+  <license>MIT</license>
+
+  <!-- This file lets catkin build this non-catkin package-->
+  <buildtool_depend>catkin</buildtool_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Let libwave be built as part of a catkin workspace.

Note this does *not* make libwave a ROS package. It just lets catkin identify it as a pure CMake package to be built. Some packages we use, such as kindr and gtsam, do the same thing.
