### PR TITLE
Rename WaveUtils to WaveHelpers.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 # CMake modules
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 INCLUDE(CMakePackageConfigHelpers)
-INCLUDE(cmake/WaveUtils.cmake)
+INCLUDE(cmake/WaveHelpers.cmake)
 ENABLE_TESTING()
 
 # User options

--- a/cmake/WaveHelpers.cmake
+++ b/cmake/WaveHelpers.cmake
@@ -1,4 +1,4 @@
-# - Macros used in libwave
+# - Functions and macros used in libwave
 
 INCLUDE(CMakeParseArguments)
 INCLUDE(GNUInstallDirs)


### PR DESCRIPTION
Avoid confusion with wave_utils module

