### PR TITLE
Disable strict-overflow warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ SET(WAVE_PACKAGE_VERSION 0.1.0)
 # Compiler settings for all targets
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+ADD_COMPILE_OPTIONS(-Wall -Wextra -Wno-strict-overflow)
 
 # Default to Release build type, otherwise some modules will be slow
 IF(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
This warning warns that the compiler assumed (N + a) > N is true by assuming N
+ a does not overflow. It is an optimization-level-dependent warning.

```
/%%%/code/libwave/wave_containers/tests/measurement_test.cpp: In member function ‘virtual void wave::FilledMeasurementContainer_getTimeWindowBackwards_Test::TestBody()’:
/%%%/code/libwave/wave_containers/tests/measurement_test.cpp:243:369: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
In file included from /%%%/code/libwave/wave_containers/include/wave/containers/measurement_container.hpp:193:0,
                 from /%%%/code/libwave/wave_containers/tests/measurement_test.cpp:3:
/%%%/code/libwave/wave_containers/include/wave/containers/impl/measurement_container.hpp:183:5: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
     if (start > end) {
     ^
```
Since signed overflow is undefined behaviour anyway, I don't see this as very
useful.

There's also not much we can do in this case since N+a is added outside of a
function, and the comparison is inside.

See https://stackoverflow.com/q/12984861/

Also use the cmake3 command add_compile_options()

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
