### PR TITLE
Fix dependency include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ INCLUDE(cmake/ImportEigen3.cmake)
 INCLUDE(cmake/ImportBoost.cmake)
 INCLUDE(cmake/ImportPCL.cmake)
 INCLUDE(cmake/ImportKindr.cmake)
+INCLUDE(cmake/ImportYaml-cpp.cmake)
 
 # Optionally build tests. `gtest` is included with this project
 IF(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ INCLUDE(cmake/ImportBoost.cmake)
 INCLUDE(cmake/ImportPCL.cmake)
 INCLUDE(cmake/ImportKindr.cmake)
 INCLUDE(cmake/ImportYaml-cpp.cmake)
+INCLUDE(cmake/ImportCeres.cmake)
 
 # Optionally build tests. `gtest` is included with this project
 IF(BUILD_TESTING)

--- a/cmake/ImportCeres.cmake
+++ b/cmake/ImportCeres.cmake
@@ -1,0 +1,10 @@
+# - Fixes imported target for ceres-solver
+# For some reason ceres does not have include directories in its imported
+# target. Add them to the target, if not already set.
+IF(TARGET ceres)
+    GET_TARGET_PROPERTY(current_property ceres INTERFACE_INCLUDE_DIRECTORIES)
+    IF(NOT current_property)
+        SET_TARGET_PROPERTIES(ceres PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+            "${CERES_INCLUDE_DIRS}")
+    ENDIF()
+ENDIF()

--- a/cmake/ImportYaml-cpp.cmake
+++ b/cmake/ImportYaml-cpp.cmake
@@ -1,0 +1,10 @@
+# - Fixes imported target for yaml-cpp
+# For some reason yaml-cpp does not have include directories in its imported
+# target. Add them to the target, if not already set.
+IF(TARGET yaml-cpp)
+    GET_TARGET_PROPERTY(current_property yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
+    IF(NOT current_property)
+        SET_TARGET_PROPERTIES(yaml-cpp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+            "${YAML_CPP_INCLUDE_DIR}")
+    ENDIF()
+ENDIF()

--- a/cmake/waveConfig.cmake.in
+++ b/cmake/waveConfig.cmake.in
@@ -102,6 +102,7 @@ INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportBoost.cmake)
 INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportPCL.cmake)
 INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportKindr.cmake)
 INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportYaml-cpp.cmake)
+INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportCeres.cmake)
 
 # This file contains definitions of IMPORTED targets
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/waveTargets.cmake")

--- a/cmake/waveConfig.cmake.in
+++ b/cmake/waveConfig.cmake.in
@@ -101,6 +101,7 @@ INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportEigen3.cmake)
 INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportBoost.cmake)
 INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportPCL.cmake)
 INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportKindr.cmake)
+INCLUDE(${WAVE_EXTRA_CMAKE_DIR}/ImportYaml-cpp.cmake)
 
 # This file contains definitions of IMPORTED targets
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/waveTargets.cmake")

--- a/wave_optimization/CMakeLists.txt
+++ b/wave_optimization/CMakeLists.txt
@@ -10,10 +10,6 @@ WAVE_ADD_MODULE(${PROJECT_NAME} DEPENDS
     src/ceres/ba.cpp
     src/ceres/ceres_examples.cpp)
 
-# For some reason Ceres does not have include directories in its imported
-# target. Add them explicitly to our target.
-TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME} SYSTEM PUBLIC ${CERES_INCLUDE_DIRS})
-
 # Unit tests
 IF(BUILD_TESTING)
     WAVE_ADD_TEST(${PROJECT_NAME}_tests


### PR DESCRIPTION
Resolves #241

For some reason yaml-cpp and Ceres do not have include directories set on their `IMPORTED` target. Add them ourselves where not already set, in separate scripts.