### PR TITLE
Immediately copy input on addPointcloud()

### DIFF
--- a/wave_matching/include/wave/matching/pointcloud_display.hpp
+++ b/wave_matching/include/wave/matching/pointcloud_display.hpp
@@ -52,9 +52,13 @@ class PointCloudDisplay {
     /**
      * Queues a pointcloud to be added to the display.
      * If worker thread isn't running nothing will happen.
+     *
+     * A copy of the cloud is taken. To show changes, call addPointcloud again
+     * with the same id.
+     *
      * @param cld: cloud to be added
-     * @param id: id of cloud to be added. Same id can be
-     * used to update cloud later
+     * @param id: identifier of cloud to be added. The id can be used to update
+     * the cloud later.
      * @param reset_camera if true, moves the camera to fit the scene
      */
     void addPointcloud(const PCLPointCloud &cld,

--- a/wave_matching/src/pointcloud_display.cpp
+++ b/wave_matching/src/pointcloud_display.cpp
@@ -42,14 +42,14 @@ void PointCloudDisplay::addPointcloud(const PCLPointCloud &cld,
                                       int id,
                                       bool reset_camera) {
     this->update_mutex.lock();
-    this->clouds.emplace(Cloud{cld, id, reset_camera});
+    this->clouds.emplace(Cloud{cld->makeShared(), id, reset_camera});
     this->update_mutex.unlock();
 }
 
 void PointCloudDisplay::addPointcloud(
   const pcl::PointCloud<pcl::PointXYZI>::Ptr &cld, int id, bool reset_camera) {
     this->update_mutex.lock();
-    this->cloudsi.emplace(CloudI{cld, id, reset_camera});
+    this->cloudsi.emplace(CloudI{cld->makeShared(), id, reset_camera});
     this->update_mutex.unlock();
 }
 


### PR DESCRIPTION
Fix #246 

Make `addPointcloud` use the input as-is during the function call. Though it adds an extra copy, it is consistent with the behaviour of the PCLVisualizer.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
