### PR TITLE
Improve PointCloudDisplay

### DIFF
--- a/wave_matching/include/wave/matching/pointcloud_display.hpp
+++ b/wave_matching/include/wave/matching/pointcloud_display.hpp
@@ -55,10 +55,15 @@ class PointCloudDisplay {
      * @param cld: cloud to be added
      * @param id: id of cloud to be added. Same id can be
      * used to update cloud later
+     * @param reset_camera if true, moves the camera to fit the scene
      */
-    void addPointcloud(const PCLPointCloud &cld, int id);
+    void addPointcloud(const PCLPointCloud &cld,
+                       int id,
+                       bool reset_camera = false);
 
-    void addPointcloud(const pcl::PointCloud<pcl::PointXYZI>::Ptr &cld, int id);
+    void addPointcloud(const pcl::PointCloud<pcl::PointXYZI>::Ptr &cld,
+                       int id,
+                       bool reset_camera = false);
 
     /**
      * Queues a line to be added to the display.
@@ -69,11 +74,13 @@ class PointCloudDisplay {
      * @param pt2 End coordinate of line
      * @param id1 Start point ID
      * @param id2 End point ID
+     * @param reset_camera if true, moves the camera to fit the scene
      */
     void addLine(const pcl::PointXYZ &pt1,
                  const pcl::PointXYZ &pt2,
                  int id1,
-                 int id2);
+                 int id2,
+                 bool reset_camera = false);
 
  private:
     std::string display_name;
@@ -101,20 +108,22 @@ class PointCloudDisplay {
     struct Cloud {
         PCLPointCloud cloud;
         int id;
+        bool reset_camera;
     };
 
     struct CloudI {
         pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
         int id;
+        bool reset_camera;
     };
 
     /** Struct for line buffer */
     struct Line {
         pcl::PointXYZ pt1, pt2;
         int id1, id2;
+        bool reset_camera;
     };
 
-    bool camera_initialized = false;
     std::queue<Cloud> clouds;
     std::queue<CloudI> cloudsi;
     std::queue<Line> lines;

--- a/wave_matching/include/wave/matching/pointcloud_display.hpp
+++ b/wave_matching/include/wave/matching/pointcloud_display.hpp
@@ -114,6 +114,7 @@ class PointCloudDisplay {
         int id1, id2;
     };
 
+    bool camera_initialized = false;
     std::queue<Cloud> clouds;
     std::queue<CloudI> cloudsi;
     std::queue<Line> lines;

--- a/wave_matching/src/pointcloud_display.cpp
+++ b/wave_matching/src/pointcloud_display.cpp
@@ -38,25 +38,28 @@ void PointCloudDisplay::spin() {
     this->viewer.reset();
 }
 
-void PointCloudDisplay::addPointcloud(const PCLPointCloud &cld, int id) {
+void PointCloudDisplay::addPointcloud(const PCLPointCloud &cld,
+                                      int id,
+                                      bool reset_camera) {
     this->update_mutex.lock();
-    this->clouds.emplace(Cloud{cld, id});
+    this->clouds.emplace(Cloud{cld, id, reset_camera});
     this->update_mutex.unlock();
 }
 
 void PointCloudDisplay::addPointcloud(
-  const pcl::PointCloud<pcl::PointXYZI>::Ptr &cld, int id) {
+  const pcl::PointCloud<pcl::PointXYZI>::Ptr &cld, int id, bool reset_camera) {
     this->update_mutex.lock();
-    this->cloudsi.emplace(CloudI{cld, id});
+    this->cloudsi.emplace(CloudI{cld, id, reset_camera});
     this->update_mutex.unlock();
 }
 
 void PointCloudDisplay::addLine(const pcl::PointXYZ &pt1,
                                 const pcl::PointXYZ &pt2,
                                 int id1,
-                                int id2) {
+                                int id2,
+                                bool reset_camera) {
     this->update_mutex.lock();
-    this->lines.emplace(Line{pt1, pt2, id1, id2});
+    this->lines.emplace(Line{pt1, pt2, id1, id2, reset_camera});
     this->update_mutex.unlock();
 }
 
@@ -84,11 +87,9 @@ void PointCloudDisplay::updateInternal() {
         } else {
             this->viewer->addPointCloud(
               cld.cloud, col_handler, std::to_string(cld.id));
-            if (!this->camera_initialized) {
-                // Fit to view for the first object added
-                this->viewer->resetCamera();
-                this->camera_initialized = true;
-            }
+        }
+        if (cld.reset_camera) {
+            this->viewer->resetCamera();
         }
         this->clouds.pop();
     }
@@ -103,11 +104,9 @@ void PointCloudDisplay::updateInternal() {
         } else {
             this->viewer->addPointCloud(
               cld.cloud, col_handler, std::to_string(cld.id));
-            if (!this->camera_initialized) {
-                // Fit to view for the first object added
-                this->viewer->resetCamera();
-                this->camera_initialized = true;
-            }
+        }
+        if (cld.reset_camera) {
+            this->viewer->resetCamera();
         }
         this->cloudsi.pop();
     }
@@ -140,6 +139,9 @@ void PointCloudDisplay::updateInternal() {
           hi,
           low,
           std::to_string(line.id1) + std::to_string(line.id2) + "ln");
+        if (line.reset_camera) {
+            this->viewer->resetCamera();
+        }
         this->lines.pop();
     }
 }

--- a/wave_matching/src/pointcloud_display.cpp
+++ b/wave_matching/src/pointcloud_display.cpp
@@ -21,9 +21,9 @@ void PointCloudDisplay::spin() {
     // Initialize viewer
     this->viewer =
       std::make_shared<pcl::visualization::PCLVisualizer>(this->display_name);
-    this->viewer->initCameraParameters();
     this->viewer->setBackgroundColor(0, 0, 0);
     this->viewer->addCoordinateSystem(1.0);
+    this->viewer->resetCamera();
     while (this->continueFlag.test_and_set(std::memory_order_relaxed) &&
            !(this->viewer->wasStopped())) {
         this->viewer->spinOnce(3);
@@ -68,6 +68,11 @@ void PointCloudDisplay::updateInternal() {
             this->viewer->updatePointCloud(cld.cloud, std::to_string(cld.id));
         } else {
             this->viewer->addPointCloud(cld.cloud, std::to_string(cld.id));
+            if (!this->camera_initialized) {
+                // Fit to view for the first object added
+                this->viewer->resetCamera();
+                this->camera_initialized = true;
+            }
         }
         this->clouds.pop();
     }
@@ -82,6 +87,11 @@ void PointCloudDisplay::updateInternal() {
         } else {
             this->viewer->addPointCloud(
               cld.cloud, col_handler, std::to_string(cld.id));
+            if (!this->camera_initialized) {
+                // Fit to view for the first object added
+                this->viewer->resetCamera();
+                this->camera_initialized = true;
+            }
         }
         this->cloudsi.pop();
     }

--- a/wave_matching/src/pointcloud_display.cpp
+++ b/wave_matching/src/pointcloud_display.cpp
@@ -64,10 +64,26 @@ void PointCloudDisplay::updateInternal() {
     // add or update clouds in the viewer until the queue is empty
     while (this->clouds.size() != 0) {
         const auto &cld = this->clouds.front();
+        // Give each id a unique color, using the Glasbey table of maximally
+        // different colors. Use white for 0
+        // Note the color handler uses the odd format of doubles 0-255
+        double r = 255., g = 255., b = 255.;
+        if (cld.id > 0 &&
+            static_cast<unsigned>(cld.id) < pcl::GlasbeyLUT::size()) {
+            const auto rgb = pcl::GlasbeyLUT::at(cld.id);
+            r = static_cast<double>(rgb.r);
+            g = static_cast<double>(rgb.g);
+            b = static_cast<double>(rgb.b);
+        }
+        pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ>
+          col_handler{cld.cloud, r, g, b};
+
         if (this->viewer->contains(std::to_string(cld.id))) {
-            this->viewer->updatePointCloud(cld.cloud, std::to_string(cld.id));
+            this->viewer->updatePointCloud(
+              cld.cloud, col_handler, std::to_string(cld.id));
         } else {
-            this->viewer->addPointCloud(cld.cloud, std::to_string(cld.id));
+            this->viewer->addPointCloud(
+              cld.cloud, col_handler, std::to_string(cld.id));
             if (!this->camera_initialized) {
                 // Fit to view for the first object added
                 this->viewer->resetCamera();

--- a/wave_matching/src/pointcloud_display.cpp
+++ b/wave_matching/src/pointcloud_display.cpp
@@ -70,16 +70,13 @@ void PointCloudDisplay::updateInternal() {
         // Give each id a unique color, using the Glasbey table of maximally
         // different colors. Use white for 0
         // Note the color handler uses the odd format of doubles 0-255
-        double r = 255., g = 255., b = 255.;
+        Eigen::Vector3d rgb{255., 255., 255.};
         if (cld.id > 0 &&
             static_cast<unsigned>(cld.id) < pcl::GlasbeyLUT::size()) {
-            const auto rgb = pcl::GlasbeyLUT::at(cld.id);
-            r = static_cast<double>(rgb.r);
-            g = static_cast<double>(rgb.g);
-            b = static_cast<double>(rgb.b);
+            rgb = pcl::GlasbeyLUT::at(cld.id).getRGBVector3i().cast<double>();
         }
         pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ>
-          col_handler{cld.cloud, r, g, b};
+          col_handler{cld.cloud, rgb[0], rgb[1], rgb[2]};
 
         if (this->viewer->contains(std::to_string(cld.id))) {
             this->viewer->updatePointCloud(

--- a/wave_matching/tests/ground_segmentation_test.cpp
+++ b/wave_matching/tests/ground_segmentation_test.cpp
@@ -82,9 +82,9 @@ TEST(ground_segmentation, how_to_use) {
 
     PointCloudDisplay display("groundsegmenter");
     display.startSpin();
-    display.addPointcloud(vizground, 1);
+    display.addPointcloud(vizground, 0);
     std::this_thread::sleep_for(std::chrono::seconds(10));
-    display.addPointcloud(vizobs, 2);
+    display.addPointcloud(vizobs, 1);
     std::this_thread::sleep_for(std::chrono::seconds(10));
 
     display.stopSpin();

--- a/wave_matching/tests/ground_segmentation_test.cpp
+++ b/wave_matching/tests/ground_segmentation_test.cpp
@@ -15,12 +15,12 @@ TEST(ground_segmentation, how_to_use) {
     GroundSegmentation ground_segmentation(params);
 
     PCLPointCloud ref;
-    pcl::PointCloud<pcl::PointXYZI>::Ptr vizobs, vizground, vizdrv;
+    pcl::PointCloud<pcl::PointXYZ>::Ptr vizobs, vizground, vizdrv;
 
     ref = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-    vizobs = boost::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-    vizground = boost::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-    vizdrv = boost::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+    vizobs = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    vizground = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    vizdrv = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
     pcl::PointCloud<PointXYZGD>::Ptr groundCloud =
       boost::make_shared<pcl::PointCloud<PointXYZGD>>();
@@ -70,21 +70,13 @@ TEST(ground_segmentation, how_to_use) {
     pcl::copyPointCloud(*obsCloud, *vizobs);
     pcl::copyPointCloud(*drvCloud, *vizdrv);
 
-    for (uint64_t i = 0; i < vizground->size(); i++) {
-        vizground->at(i).intensity = 1;
-    }
-    for (uint64_t i = 0; i < vizdrv->size(); i++) {
-        vizdrv->at(i).intensity = 2;
-    }
-    for (uint64_t i = 0; i < vizobs->size(); i++) {
-        vizobs->at(i).intensity = 3;
-    }
-
     PointCloudDisplay display("groundsegmenter");
     display.startSpin();
     display.addPointcloud(vizground, 0);
-    std::this_thread::sleep_for(std::chrono::seconds(10));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     display.addPointcloud(vizobs, 1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    display.addPointcloud(vizdrv, 1);
     std::this_thread::sleep_for(std::chrono::seconds(10));
 
     display.stopSpin();

--- a/wave_matching/tests/ground_segmentation_test.cpp
+++ b/wave_matching/tests/ground_segmentation_test.cpp
@@ -72,11 +72,11 @@ TEST(ground_segmentation, how_to_use) {
 
     PointCloudDisplay display("groundsegmenter");
     display.startSpin();
-    display.addPointcloud(vizground, 0);
+    display.addPointcloud(vizground, 0, true);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     display.addPointcloud(vizobs, 1);
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    display.addPointcloud(vizdrv, 1);
+    display.addPointcloud(vizdrv, 2);
     std::this_thread::sleep_for(std::chrono::seconds(10));
 
     display.stopSpin();

--- a/wave_matching/tests/pointcloud_display_tests.cpp
+++ b/wave_matching/tests/pointcloud_display_tests.cpp
@@ -22,7 +22,7 @@ TEST(viewer, pointcloud_test) {
     display.startSpin();
     PCLPointCloud cloud = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::io::loadPCDFile(TEST_SCAN, *cloud);
-    display.addPointcloud(cloud, 1);
+    display.addPointcloud(cloud, 0);
     std::this_thread::sleep_for(std::chrono::seconds(5));
     display.stopSpin();
 }
@@ -32,11 +32,11 @@ TEST(viewer, multiple_clouds_test) {
     display.startSpin();
     PCLPointCloud cloud = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::io::loadPCDFile(TEST_SCAN, *cloud);
-    display.addPointcloud(cloud, 1);
+    display.addPointcloud(cloud, 0);
     Eigen::Affine3f transform(Eigen::Translation3f(Eigen::Vector3f(20, 0, 0)));
     for (int i = 0; i < 3; i++) {
         pcl::transformPointCloud(*cloud, *cloud, transform);
-        display.addPointcloud(cloud, i + 2);
+        display.addPointcloud(cloud, i + 1);
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
     std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/wave_matching/tests/pointcloud_display_tests.cpp
+++ b/wave_matching/tests/pointcloud_display_tests.cpp
@@ -22,7 +22,7 @@ TEST(viewer, pointcloud_test) {
     display.startSpin();
     PCLPointCloud cloud = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::io::loadPCDFile(TEST_SCAN, *cloud);
-    display.addPointcloud(cloud, 0);
+    display.addPointcloud(cloud, 0, true);
     std::this_thread::sleep_for(std::chrono::seconds(5));
     display.stopSpin();
 }
@@ -32,7 +32,7 @@ TEST(viewer, multiple_clouds_test) {
     display.startSpin();
     PCLPointCloud cloud = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     pcl::io::loadPCDFile(TEST_SCAN, *cloud);
-    display.addPointcloud(cloud, 0);
+    display.addPointcloud(cloud, 0, true);
     Eigen::Affine3f transform(Eigen::Translation3f(Eigen::Vector3f(20, 0, 0)));
     for (int i = 0; i < 3; i++) {
         pcl::transformPointCloud(*cloud, *cloud, transform);
@@ -63,7 +63,7 @@ TEST(viewer, pointcloud_intensity) {
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud =
       boost::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
     pcl::io::loadPCDFile(TEST_SCAN, *cloud);
-    display.addPointcloud(cloud, 1);
+    display.addPointcloud(cloud, 1, true);
     std::this_thread::sleep_for(std::chrono::seconds(5));
     display.stopSpin();
 }


### PR DESCRIPTION
Small usability improvements

- Initialize camera slightly above the axes instead of right on them
- Zoom out to show the ~first added cloud~ whole scene if `reset_camera` argument is given to `addPointcloud`
- Give each id of pointcloud a different color

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests (manually tested `wave_matching_viz_tests` and `wave_matching_ground_segmentation_tests`)
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
