### PR TITLE
Add explicit dependency on opencv modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ FIND_PACKAGE(Boost 1.54.0 COMPONENTS system filesystem)
 FIND_PACKAGE(PCL 1.8 COMPONENTS
     common filters registration kdtree search io visualization)
 FIND_PACKAGE(kindr)
-FIND_PACKAGE(OpenCV 3.2.0 COMPONENTS core features2d calib3d imgproc highgui)
+FIND_PACKAGE(OpenCV 3.2.0)
 FIND_PACKAGE(yaml-cpp REQUIRED)
 FIND_PACKAGE(Ceres 1.12)
 

--- a/wave_vision/CMakeLists.txt
+++ b/wave_vision/CMakeLists.txt
@@ -8,6 +8,7 @@ WAVE_ADD_MODULE(${PROJECT_NAME}
     Eigen3::Eigen
     Boost::filesystem
     opencv_core opencv_features2d opencv_calib3d opencv_imgproc opencv_highgui
+    opencv_videoio
     SOURCES
     src/utils.cpp
     src/dataset/VoDataset.cpp


### PR DESCRIPTION
Resolves reported build errors.
The vision module depends on ~xfeatures2d~ videoio, but did not specify the dependency.

**Previous behaviour**
When videoio module is not installed, wave_vision is still configured to build and fails during build.

**New behaviour**
When videoio is not found, wave_vision is disabled and not built (this prints a status message, not a warning or error).