### PR TITLE
Fix ground segmentation bug

### DIFF
--- a/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
+++ b/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
@@ -309,19 +309,19 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
             } else {
                 // check drivability
                 if (h > this->params.robot_height) {
-                    // drivable
-                } else {
-                    this->drv_indices.push_back(j);  // add to obs
-                    // @todo wrong comment above, or wrong code?
+                    // @todo repetitive code
+                    this->drv_indices.push_back(j);
                     cur_cell.drv_indices.push_back(j);
+                } else {
+                    this->obs_indices.push_back(j);
+                    cur_cell.obs_indices.push_back(j);
+                    obs_sum += Vec3(cur_point.x, cur_point.y, cur_point.z);
+                    num_obs++;
                 }
-                this->obs_indices.push_back(j);  // add to obs
-                cur_cell.obs_indices.push_back(j);
-                obs_sum += Vec3(cur_point.x, cur_point.y, cur_point.z);
-                num_obs++;
             }
         }
         // mean of obs points
+        // @todo is this unused?
         cur_cell.obs_mean = obs_sum / num_obs;
     }
 
@@ -338,18 +338,19 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
                 float h = std::abs(cur_point.z - f_s(i));
                 // check drivability
                 if (h > this->params.robot_height) {
-                    // drivable
-                } else {
-                    this->drv_indices.push_back(j);  // add to obs
-                    // @todo wrong comment above, or wrong code?
+                    // @todo repetitive code
+                    this->drv_indices.push_back(j);
                     cur_cell.drv_indices.push_back(j);
+                } else {
+                    this->obs_indices.push_back(j);
+                    cur_cell.obs_indices.push_back(j);
+                    cur_cell.obs_indices.push_back(j);
+                    obs_sum += Vec3{cur_point.x, cur_point.y, cur_point.z};
+                    num_obs++;
                 }
-                this->obs_indices.push_back(j);  // add to obs
-                cur_cell.obs_indices.push_back(j);
-                obs_sum += Vec3{cur_point.x, cur_point.y, cur_point.z};
-                num_obs++;
             }
             // mean of obs points
+            // @todo is this unused?
             cur_cell.obs_mean = obs_sum / num_obs;
         }
     } else {

--- a/wave_matching/tests/ground_segmentation_test.cpp
+++ b/wave_matching/tests/ground_segmentation_test.cpp
@@ -16,9 +16,9 @@ TEST(ground_segmentation, how_to_use) {
 
     PCLPointCloudPtr input =
       boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-    auto vizground = input->makeShared();
-    auto vizobs = input->makeShared();
-    auto vizdrv = input->makeShared();
+    auto out_ground = input->makeShared();
+    auto out_obs = input->makeShared();
+    auto out_drv = input->makeShared();
 
 
     pcl::io::loadPCDFile(TEST_SCAN, *input);
@@ -61,24 +61,26 @@ TEST(ground_segmentation, how_to_use) {
     ground_segmentation.setKeepGround(true);
     ground_segmentation.setKeepObstacle(false);
     ground_segmentation.setKeepOverhanging(false);
-    ground_segmentation.filter(*vizground);
+    ground_segmentation.filter(*out_ground);
 
     ground_segmentation.setKeepGround(false);
     ground_segmentation.setKeepObstacle(true);
-    ground_segmentation.filter(*vizobs);
+    ground_segmentation.filter(*out_obs);
 
     ground_segmentation.setKeepObstacle(false);
     ground_segmentation.setKeepOverhanging(true);
-    ground_segmentation.filter(*vizdrv);
+    ground_segmentation.filter(*out_drv);
 
     PointCloudDisplay display("groundsegmenter");
     display.startSpin();
-    display.addPointcloud(vizground, 0, true);
+    display.addPointcloud(input, 0, true);
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    display.addPointcloud(vizobs, 1);
+    display.addPointcloud(out_ground, 1);
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    display.addPointcloud(vizdrv, 2);
-    std::this_thread::sleep_for(std::chrono::seconds(10));
+    display.addPointcloud(out_obs, 2);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    display.addPointcloud(out_drv, 3);
+    std::this_thread::sleep_for(std::chrono::seconds(20));
 
     display.stopSpin();
 }


### PR DESCRIPTION
Fixes #254

Before: both low and high points labeled as obstacles, low obstacles labeled as overhanging ("drivable")
Now: low points labeled obstacles, high points labeled overhanging


#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [ ] Code has automated tests - visual test only
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
