### PR TITLE
Replace nonstandard exception with std::runtime_error

### DIFF
--- a/wave_matching/include/wave/matching/matcher.hpp
+++ b/wave_matching/include/wave/matching/matcher.hpp
@@ -10,19 +10,11 @@
 #ifndef WAVE_MATCHING_MATCHER_HPP
 #define WAVE_MATCHING_MATCHER_HPP
 
-#include <exception>
-
 #include "wave/utils/utils.hpp"
 
 namespace wave {
 /** @addtogroup matching
  *  @{ */
-
-class ConfigException : public __exception {
-    virtual const char *what() const throw() {
-        return "Failed to Load Matcher Config";
-    }
-};
 
 /**
  * This class is inherited by each of the different matching algorithms.

--- a/wave_matching/src/gicp.cpp
+++ b/wave_matching/src/gicp.cpp
@@ -13,8 +13,7 @@ GICPMatcherParams::GICPMatcherParams(const std::string &config_path) {
     parser.addParam("fit_eps", &fit_eps);
 
     if (parser.load(config_path) != ConfigStatus::OK) {
-        ConfigException config_exception;
-        throw config_exception;
+        throw std::runtime_error{"Failed to Load Matcher Config"};
     }
 }
 

--- a/wave_matching/src/icp.cpp
+++ b/wave_matching/src/icp.cpp
@@ -16,8 +16,7 @@ ICPMatcherParams::ICPMatcherParams(const std::string &config_path) {
     parser.addParam("multiscale_steps", &(this->multiscale_steps));
 
     if (parser.load(config_path) != ConfigStatus::OK) {
-        ConfigException config_exception;
-        throw config_exception;
+        throw std::runtime_error{"Failed to Load Matcher Config"};
     }
 
     if ((covar_est_temp >= ICPMatcherParams::covar_method::LUM) &&

--- a/wave_matching/src/ndt.cpp
+++ b/wave_matching/src/ndt.cpp
@@ -11,8 +11,7 @@ NDTMatcherParams::NDTMatcherParams(const std::string &config_path) {
     parser.addParam("res", &this->res);
 
     if (parser.load(config_path) != ConfigStatus::OK) {
-        ConfigException config_exception;
-        throw config_exception;
+        throw std::runtime_error{"Failed to Load Matcher Config"};
     }
 }
 


### PR DESCRIPTION
`__exception` is an implementation-specific reserved name. It cannot be used in our library.
Replace `ConfigException` with `std::runtime_error` for now. If a custom exception type is really desired, you can properly inherit from a standard exception type in future.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
