### PR TITLE
Fix wrong constructor for opencv3.3

### DIFF
--- a/wave_vision/src/utils.cpp
+++ b/wave_vision/src/utils.cpp
@@ -137,7 +137,7 @@ bool convert<cv::Mat>::decode(const Node &node, cv::Mat &out) {
     }
 
     // Copy it to destination
-    out = cv::Mat{rows, cols, CV_64F};
+    out = cv::Mat(rows, cols, CV_64F);
     for (int i = 0, index = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
             out.at<double>(i, j) = node["data"][index++].as<double>();


### PR DESCRIPTION
Fix #270

OpenCV broke their API.

Checked that this is the only place `cv::Mat` brace-initializer was used.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
