### PR TITLE
CMake: set compatibility to ExactVersion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,9 +131,12 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
     INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}")
 
 # Generate the Version file
+# This build is only considered compatible with the exact version requested
+# (not SameMajorVersion) for now since the API is often broken by active
+# development.
 WRITE_BASIC_PACKAGE_VERSION_FILE(waveConfigVersion.cmake
     VERSION ${WAVE_PACKAGE_VERSION}
-    COMPATIBILITY SameMajorVersion)
+    COMPATIBILITY ExactVersion)
 
 # Install the Config and ConfigVersion files
 INSTALL(FILES

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This library contains reusable code for:
 - Vision
 - and more ..
 
+libwave is in the initial development stage, meaning the API can change at any
+time without warning.
+
 ## Requirements
 
 - Boost 1.54


### PR DESCRIPTION
We are breaking API all the time due to development.

- Add a note about API breaking to ReadMe
- Set CMake compatibility to `ExactVersion`, meaning a dependee asking for libwave 0.1.0 will get an error if 0.1.1 or 0.2.0 is installed.

Eventually we want to move to [semantic versioning](https://semver.org/), but currently we are in what that standard calls the "initial development phase":

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

We should start incrementening the minor version though.

