### PR TITLE
Tweak ICPMatcher to allow reusing target kdtree

### DIFF
--- a/wave_matching/include/wave/matching/icp.hpp
+++ b/wave_matching/include/wave/matching/icp.hpp
@@ -72,7 +72,7 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
      * each voxel. If resolution is non-positive, no downsampling is used.
      */
     explicit ICPMatcher(const ICPMatcherParams &params);
-    ~ICPMatcher();
+    ~ICPMatcher() = default;
 
     /** Sets the parameters used by subsequent matches */
     void setParams(const ICPMatcherParams &params);
@@ -109,7 +109,15 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
      * is not exposed. PCL's ICP class creates an aligned verison of the target
      * pointcloud after matching, so the "final" member is used as a sink for
      * it. */
-    PCLPointCloudPtr ref, target, final, downsampled_ref, downsampled_target;
+    PCLPointCloudPtr ref = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    PCLPointCloudPtr target =
+      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    PCLPointCloudPtr final =
+      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    PCLPointCloudPtr downsampled_ref =
+      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    PCLPointCloudPtr downsampled_target =
+      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
     /**
      * Calculates a covariance estimate based on Lu and Milios Scan Matching

--- a/wave_matching/include/wave/matching/icp.hpp
+++ b/wave_matching/include/wave/matching/icp.hpp
@@ -100,6 +100,20 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
     /** Reads the `params` member and updates other members */
     void updateFromParams();
 
+    /**
+     * Calculates a covariance estimate based on Lu and Milios Scan Matching
+     */
+    void estimateLUM();
+    void estimateLUMold();
+
+    /**
+     * Calculates a covariance estimate based on Censi
+     */
+    void estimateCensi();
+
+ private:
+    ICPMatcherParams params;
+
     /** An instance of the ICP class from PCL */
     pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
     /** An instance of a PCL voxel filter. It is used to downsample input. */
@@ -119,19 +133,9 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
     PCLPointCloudPtr downsampled_target =
       boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
-    /**
-     * Calculates a covariance estimate based on Lu and Milios Scan Matching
-     */
-    void estimateLUM();
-    void estimateLUMold();
-
-    /**
-     * Calculates a covariance estimate based on Censi
-     */
-    void estimateCensi();
-
- private:
-    ICPMatcherParams params;
+    // Set true when `ref` or `target` changed; next match needs to use new ones
+    bool ref_updated = true;
+    bool target_updated = true;
 };
 
 /** @} group matching */

--- a/wave_matching/include/wave/matching/icp.hpp
+++ b/wave_matching/include/wave/matching/icp.hpp
@@ -71,8 +71,11 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
      * downsampled using a voxel filter, the argument is the edge length of
      * each voxel. If resolution is non-positive, no downsampling is used.
      */
-    explicit ICPMatcher(ICPMatcherParams params1);
+    explicit ICPMatcher(const ICPMatcherParams &params);
     ~ICPMatcher();
+
+    /** Sets the parameters used by subsequent matches */
+    void setParams(const ICPMatcherParams &params);
 
     /** sets the reference pointcloud for the matcher
      * @param ref - Pointcloud
@@ -93,9 +96,10 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
      */
     void estimateInfo();
 
-    ICPMatcherParams params;
-
  private:
+    /** Reads the `params` member and updates other members */
+    void updateFromParams();
+
     /** An instance of the ICP class from PCL */
     pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
     /** An instance of a PCL voxel filter. It is used to downsample input. */
@@ -117,6 +121,9 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
      * Calculates a covariance estimate based on Censi
      */
     void estimateCensi();
+
+ private:
+    ICPMatcherParams params;
 };
 
 /** @} group matching */

--- a/wave_matching/include/wave/matching/icp.hpp
+++ b/wave_matching/include/wave/matching/icp.hpp
@@ -87,6 +87,10 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
      */
     void setTarget(const PCLPointCloudPtr &target);
 
+    PCLPointCloudPtr getTarget() const {
+        return this->target;
+    };
+
     /** runs the matcher, blocks until finished.
      * Returns true if successful
      */
@@ -132,10 +136,6 @@ class ICPMatcher : public Matcher<PCLPointCloudPtr> {
       boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     PCLPointCloudPtr downsampled_target =
       boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-
-    // Set true when `ref` or `target` changed; next match needs to use new ones
-    bool ref_updated = true;
-    bool target_updated = true;
 };
 
 /** @} group matching */

--- a/wave_matching/src/icp.cpp
+++ b/wave_matching/src/icp.cpp
@@ -30,7 +30,7 @@ ICPMatcherParams::ICPMatcherParams(const std::string &config_path) {
 }
 
 ICPMatcher::ICPMatcher(const ICPMatcherParams &params) : params(params) {
-    this->ref = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    this->ref =
     this->target = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     this->final = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     this->downsampled_ref =
@@ -39,20 +39,6 @@ ICPMatcher::ICPMatcher(const ICPMatcherParams &params) : params(params) {
       boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
     this->updateFromParams();
-}
-
-ICPMatcher::~ICPMatcher() {
-    if (this->ref) {
-        this->ref.reset();
-        this->downsampled_ref.reset();
-    }
-    if (this->target) {
-        this->target.reset();
-        this->downsampled_target.reset();
-    }
-    if (this->final) {
-        this->final.reset();
-    }
 }
 
 void ICPMatcher::setParams(const ICPMatcherParams &params) {

--- a/wave_matching/src/icp.cpp
+++ b/wave_matching/src/icp.cpp
@@ -29,7 +29,7 @@ ICPMatcherParams::ICPMatcherParams(const std::string &config_path) {
     }
 }
 
-ICPMatcher::ICPMatcher(ICPMatcherParams params1) : params(params1) {
+ICPMatcher::ICPMatcher(const ICPMatcherParams &params) : params(params) {
     this->ref = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     this->target = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
     this->final = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
@@ -38,16 +38,7 @@ ICPMatcher::ICPMatcher(ICPMatcherParams params1) : params(params1) {
     this->downsampled_target =
       boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
-    if (this->params.res > 0) {
-        this->filter.setLeafSize(
-          this->params.res, this->params.res, this->params.res);
-    }
-    this->resolution = this->params.res;
-
-    this->icp.setMaxCorrespondenceDistance(this->params.max_corr);
-    this->icp.setMaximumIterations(this->params.max_iter);
-    this->icp.setTransformationEpsilon(this->params.t_eps);
-    this->icp.setEuclideanFitnessEpsilon(this->params.fit_eps);
+    this->updateFromParams();
 }
 
 ICPMatcher::~ICPMatcher() {
@@ -62,6 +53,23 @@ ICPMatcher::~ICPMatcher() {
     if (this->final) {
         this->final.reset();
     }
+}
+
+void ICPMatcher::setParams(const ICPMatcherParams &params) {
+    this->params = params;
+}
+
+void ICPMatcher::updateFromParams() {
+    if (this->params.res > 0) {
+        this->filter.setLeafSize(
+          this->params.res, this->params.res, this->params.res);
+    }
+    this->resolution = this->params.res;
+
+    this->icp.setMaxCorrespondenceDistance(this->params.max_corr);
+    this->icp.setMaximumIterations(this->params.max_iter);
+    this->icp.setTransformationEpsilon(this->params.t_eps);
+    this->icp.setEuclideanFitnessEpsilon(this->params.fit_eps);
 }
 
 void ICPMatcher::setRef(const PCLPointCloudPtr &ref) {

--- a/wave_matching/src/icp.cpp
+++ b/wave_matching/src/icp.cpp
@@ -30,14 +30,6 @@ ICPMatcherParams::ICPMatcherParams(const std::string &config_path) {
 }
 
 ICPMatcher::ICPMatcher(const ICPMatcherParams &params) : params(params) {
-    this->ref = this->target =
-      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-    this->final = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-    this->downsampled_ref =
-      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-    this->downsampled_target =
-      boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-
     this->updateFromParams();
 }
 


### PR DESCRIPTION
The specific use case targeted is:
- I want to call setTarget _once_ and call setRef multiple times, without forcing kdl to rebuild the target kdree every time.
- I don't use downsampling and multiscale matching within the ICPMatcher, so I don't care about the reusing the kdtree in those cases.
- Also, I want to be able to change parameters of an _existing_ `ICPMatcher`

Plus a bit of constructor and destructor cleanup.

Specific changes:
- call setInputTarget() in setRef(), etc.
  - an optimization in the special case described above; no effect in the simpler "no downsampling" case; negligible cost of a wasted call in the "yes downsampling" case
- Separate param setter from constructor
- Add `getTarget()`, `getRef()` convenience methods
- Simplify ctor & dtor
  - Resetting smart pointers in dtor is not necessary
  - Replace assignments with in-class initializers

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
