### PR TITLE
Fix memory leak in GroundSegmentation

### DIFF
--- a/wave_matching/include/wave/matching/ground_segmentation.hpp
+++ b/wave_matching/include/wave/matching/ground_segmentation.hpp
@@ -63,8 +63,11 @@ struct AngCell {
 };
 
 /**
-*  Structure to hold all angular bins
-*/
+ *  Structure to hold all angular bins
+ *
+ *  For now there is not much point to having this as a separate struct.
+ *  @todo refactor methods genPolarBinGrid() and initializePolarBinGrid() here.
+ */
 struct PolarBinGrid {
     std::vector<AngCell, Eigen::aligned_allocator<AngCell>> ang_cells;
 };
@@ -150,7 +153,7 @@ class GroundSegmentation : public pcl::Filter<PointT> {
     // Data storage
     // The input pointcloud is in the input_ member inherited from pcl::Filter.
     // Instead of copying points, we keep track of indices to input_.
-    PolarBinGrid *polar_bin_grid;
+    PolarBinGrid polar_bin_grid;
     std::vector<int> ground_indices;  // indices of ground points in input cloud
     std::vector<int> obs_indices;  // indices of obstacle points in input cloud
     std::vector<int> drv_indices;  // indices of drivable points in input cloud

--- a/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
+++ b/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
@@ -11,16 +11,15 @@ template <typename PointT>
 GroundSegmentation<PointT>::GroundSegmentation(
   const GroundSegmentationParams &config)
     : params{config} {
-    this->polar_bin_grid = new PolarBinGrid;
     this->initializePolarBinGrid();
 }
 
 template <typename PointT>
 void GroundSegmentation<PointT>::initializePolarBinGrid() {
-    this->polar_bin_grid->ang_cells.clear();
-    this->polar_bin_grid->ang_cells.resize(this->params.num_bins_a);
+    this->polar_bin_grid.ang_cells.clear();
+    this->polar_bin_grid.ang_cells.resize(this->params.num_bins_a);
     for (int i = 0; i < this->params.num_bins_a; i++) {
-        auto &ang_cell = this->polar_bin_grid->ang_cells[i];
+        auto &ang_cell = this->polar_bin_grid.ang_cells[i];
         ang_cell.lin_cell.resize(this->params.num_bins_l);
         ang_cell.sig_points.resize(this->params.num_bins_l);
         ang_cell.range_height_signal.resize(this->params.num_bins_l);
@@ -62,22 +61,22 @@ void GroundSegmentation<PointT>::genPolarBinGrid() {
             unsigned int bind_lin = static_cast<unsigned int>(
               xy_dist / bsize_lin);  // got the radial bin
 
-            this->polar_bin_grid->ang_cells[bind_rad]
+            this->polar_bin_grid.ang_cells[bind_rad]
               .lin_cell[bind_lin]
               .bin_indices.push_back(i);
             // add the point to the bin
             // check the protoype point
-            auto &prototype_index = polar_bin_grid->ang_cells[bind_rad]
+            auto &prototype_index = polar_bin_grid.ang_cells[bind_rad]
                                       .lin_cell[bind_lin]
                                       .prototype_index;
             if (prototype_index < 0 ||
                 pz < (*this->input_)[prototype_index].z)  // smallest by z
             {
                 prototype_index = i;
-                this->polar_bin_grid->ang_cells[bind_rad]
+                this->polar_bin_grid.ang_cells[bind_rad]
                   .range_height_signal[bind_lin]
                   .x = xy_dist;
-                this->polar_bin_grid->ang_cells[bind_rad]
+                this->polar_bin_grid.ang_cells[bind_rad]
                   .range_height_signal[bind_lin]
                   .y = pz;
             }
@@ -114,22 +113,22 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
     int num_filled = 0;
 
     // pull out the valid points from the sector
-    auto &sig_points = polar_bin_grid->ang_cells[sector_index].sig_points;
+    auto &sig_points = polar_bin_grid.ang_cells[sector_index].sig_points;
     sig_points.clear();
     for (int i = 0; i < this->params.num_bins_l; i++) {
-        if (!std::isnan(polar_bin_grid->ang_cells[sector_index]
+        if (!std::isnan(polar_bin_grid.ang_cells[sector_index]
                           .range_height_signal[i]
                           .x) &&
-            this->polar_bin_grid->ang_cells[sector_index]
+            this->polar_bin_grid.ang_cells[sector_index]
                 .lin_cell[i]
                 .bin_indices.size() > 5) {
             // bin has a valid point, and enough points to make a good
             // guess for a protopoint
             SignalPoint new_point;
             new_point.range =
-              polar_bin_grid->ang_cells[sector_index].range_height_signal[i].x;
+              polar_bin_grid.ang_cells[sector_index].range_height_signal[i].x;
             new_point.height =
-              polar_bin_grid->ang_cells[sector_index].range_height_signal[i].y;
+              polar_bin_grid.ang_cells[sector_index].range_height_signal[i].y;
             new_point.index = i;
             sig_points.push_back(new_point);
             num_filled++;
@@ -295,7 +294,7 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
     for (int i = 0; i < (int) current_model.size(); i++) {
         int currIdx = current_model[i].index;
         auto &cur_cell =
-          this->polar_bin_grid->ang_cells[sector_index].lin_cell[currIdx];
+          this->polar_bin_grid.ang_cells[sector_index].lin_cell[currIdx];
 
         // go through all the points in this cell and assign to ground/not
         // ground
@@ -330,7 +329,7 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
     if (sufficient_model) {
         // add all the obs points from the non ground classified pts
         for (i = 0; i < (int) sig_points.size(); i++) {
-            auto &cur_cell = polar_bin_grid->ang_cells[sector_index]
+            auto &cur_cell = polar_bin_grid.ang_cells[sector_index]
                                .lin_cell[sig_points[i].index];
 
             for (const auto j : cur_cell.bin_indices) {


### PR DESCRIPTION
Resolves #285

Replace new-initialized pointer to PolarBinGrid with a non-pointer member.

Actually, it looks like there is no point to having a separate PolarBinGrid struct anyway. Some methods could be refactored. Add a @todo note to this effect.

#### Pre-Merge Checklist:
- [x] Code is documented in doxygen format
- [x] Code has automated tests
- [x] Zero compiler warnings
- [x] Formatted with `clang-format`
