### PR TITLE
Log debug ground segmentation

### DIFF
--- a/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
+++ b/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
@@ -227,7 +227,7 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
 
         if (Vf_s.rows() == 0) {
             keep_going = false;
-            LOG_DEBUG("WARNING BREAKING LOOP: VF_s does not exist");
+            ROS_DEBUG_THROTTLE_NAMED(2, "Ground segmentation", "BREAKING LOOP: VF_s does not exist");
             continue;
         }
 
@@ -352,7 +352,7 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
             cur_cell.obs_mean = obs_sum / num_obs;
         }
     } else {
-        LOG_DEBUG("WARNING:Insufficient Model for angular slice");
+        ROS_DEBUG_THROTTLE_NAMED(2, "Ground segmentation", "Insufficient Model for angular slice");
     }
 }
 

--- a/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
+++ b/wave_matching/include/wave/matching/impl/ground_segmentation.hpp
@@ -227,7 +227,7 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
 
         if (Vf_s.rows() == 0) {
             keep_going = false;
-            LOG_INFO("WARNING BREAKING LOOP: VF_s does not exist");
+            LOG_DEBUG("WARNING BREAKING LOOP: VF_s does not exist");
             continue;
         }
 
@@ -352,7 +352,7 @@ void GroundSegmentation<PointT>::sectorINSAC(int sector_index) {
             cur_cell.obs_mean = obs_sum / num_obs;
         }
     } else {
-        LOG_INFO("WARNING:Insufficient Model for angular slice");
+        LOG_DEBUG("WARNING:Insufficient Model for angular slice");
     }
 }
 


### PR DESCRIPTION
Reduce console spam by using `ROS_DEBUG_THROTTLE_NAMED`.

Ground segmentation keeps spamming console with
```
WARNING:Insufficient Model for angular slice
```